### PR TITLE
Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ To build the container that runs the app, type `docker build -t uat .`
 To run the application, run `docker run -it -p 9000:9000 -v ${PWD}/universal-application-tool-0.0.1:/code uat sbt ~run`
 This enables hot-reloading - when you modify files, the server will recompile and restart.
 After this, you can access the server at localhost:9000.
+
+To launch postgres and adminer along with play app, run `./bin/run-dev`
+This will start 3 individual containers.
+You can access play app at localhost:9000 as before, and adminer at localhost:8080.

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -it -p 9000:9000 -v ${PWD}/universal-application-tool-0.0.1:/code uat sbt ~run
+docker-compose -f stack.yml up

--- a/stack.yml
+++ b/stack.yml
@@ -1,0 +1,25 @@
+# Use postgres/example user/password credentials
+version: '3.1'
+
+services:
+
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: example
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+
+  uat:
+    image: uat
+    restart: always
+    ports:
+      - 9000:9000
+    volumes:
+      - ./universal-application-tool-0.0.1:/code
+    command: sbt ~run

--- a/stack.yml
+++ b/stack.yml
@@ -18,6 +18,8 @@ services:
   uat:
     image: uat
     restart: always
+    links:
+      - "db:database"
     ports:
       - 9000:9000
     volumes:


### PR DESCRIPTION
Add a docker compose file stack.yml that allows a way to launch multiple containers at the same time.
The 3 containers are the sample play app in image uat, a postgres instance, and a adminer instance for postgres.
Right now the play app does not interact with postgres instance in any way.