### PR TITLE
file naming convention change: Docker Swarm -> Docker Compose

### DIFF
--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose -f stack.yml up
+docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,4 +24,5 @@ services:
       - 9000:9000
     volumes:
       - ./universal-application-tool-0.0.1:/code
+    build: .
     command: sbt ~run


### PR DESCRIPTION
Docker swarm (`stack.yml`) is the go-to if you need multiple machines to coordinate but want something lighter weight than kubernetes.  Docker compose (`docker-compose.yml`) runs only on one machine but is much simpler want to be able to inspect it as it goes.

Before, we thought we'd need to run on-prem, so created the compose file with the intention of using it in a swarm, but we are newly confident we can count on a cloud provider, so we can change it back to the default name.