### PR TITLE
Add `migrate` tool and handy shortcuts for using it, plus first example table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ This will start 3 individual containers.
 You can access play app at localhost:9000 as before, and adminer at localhost:8080.
 
 To format java code locally, run './bin/fmt', from either this directory or the root of the project.
+
+## Database Schema Management
+In order to enable the frequent changes to the schema that we expect in the early days of this project, we are using the `migrate` tool.
+Fundamentally this is a tool which treats a database schema as a sequence of statements to apply.  In order to ensure that everyone is able to
+migrate from early versions to later versions, as well as vice-versa, these statements are generated in pairs - `up` and `down` - and ordered.
+
+You can read a lot about this tool [here](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate).
+It is provided in a convenient docker container, and configuration for connecting that container to the postgres container we have in
+our docker-compose stack is provided in `./bin/schematool`.  Some handy commands are:
+  - `./bin/schematool` - bring database to most recent version.  (apply all migrations in order)
+  - `./bin/schematool create -seq -ext sql -dir /migrations some_name` - create an empty new set of migrations (up and down) with name `some_name`.
+  - `./bin/schematool down -all` - reset database to empty.
+  - `./bin/schematool up 5` - bring database to migration number "5", if currently version is lower than 5.
+  - `./bin/schematool down 5` - bring database to migration number "5", if currently version is higher than 5.
+
+We also have a command to completely destroy and recreate the entire database - `./bin/clear-dev-db`.  This command only works if the database is currently stopped, and requires root permissions since the db uses a non-default user to store its data.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ After this, you can access the server at localhost:9000.
 To launch postgres and adminer along with play app, run `./bin/run-dev`
 This will start 3 individual containers.
 You can access play app at localhost:9000 as before, and adminer at localhost:8080.
+
+To format java code locally, run './bin/fmt', from either this directory or the root of the project.

--- a/bin/clear-dev-db
+++ b/bin/clear-dev-db
@@ -1,0 +1,5 @@
+#! /bin/bash
+set -e
+docker-compose rm db
+sudo rm -rf ~/.uat/postgres
+mkdir -p ~/.uat/postgres

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -1,2 +1,3 @@
 #!/bin/bash
+mkdir -p ~/.uat/postgres
 docker-compose up

--- a/bin/schematool
+++ b/bin/schematool
@@ -1,0 +1,8 @@
+#! /bin/bash
+if [ $# -eq 0 ]; then
+	ARG=up
+else
+	ARG=$@
+fi
+
+docker run -v $PWD/dbschema:/migrations --network universal-application-tool_default migrate/migrate -path=/migrations/ -verbose -database "postgres://uat:localdbonly@db/uat?sslmode=disable" $ARG

--- a/dbschema/00001_initial.down.sql
+++ b/dbschema/00001_initial.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/dbschema/00001_initial.up.sql
+++ b/dbschema/00001_initial.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS users(
+	user_id serial PRIMARY KEY,
+	idcs_id VARCHAR(50) UNIQUE
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,17 @@ services:
     image: postgres
     restart: always
     environment:
-      POSTGRES_PASSWORD: example
-
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - 8080:8080
+      POSTGRES_USER: uat
+      POSTGRES_PASSWORD: localdbonly
+      POSTGRES_DB: uat
+    volumes:
+      - ~/.uat/postgres:/var/lib/postgresql/data
 
   uat:
     image: uat
     restart: always
+    depends_on:
+      - db
     links:
       - "db:database"
     ports:


### PR DESCRIPTION
Related to #9.

Description, copied from readme additions:

## Database Schema Management
In order to enable the frequent changes to the schema that we expect in the early days of this project, we are using the `migrate` tool.

Fundamentally this is a tool which treats a database schema as a sequence of statements to apply.  In order to ensure that everyone is able to migrate from early versions to later versions, as well as vice-versa, these statements are generated in pairs - `up` and `down` - and ordered.

You can read a lot about this tool [here](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate).
It is provided in a convenient docker container, and configuration for connecting that container to the postgres container we have in our docker-compose stack is provided in `./bin/schematool`.  Some handy commands are:
  - `./bin/schematool` - bring database to most recent version.  (apply all migrations in order)
  - `./bin/schematool create -seq -ext sql -dir /migrations some_name` - create an empty new set of migrations (up and down) with name `some_name`.
  - `./bin/schematool down -all` - reset database to empty.
  - `./bin/schematool up 5` - bring database to migration number "5", if currently version is lower than 5.
  - `./bin/schematool down 5` - bring database to migration number "5", if currently version is higher than 5.

We also have a command to completely destroy and recreate the entire database - `./bin/clear-dev-db`.  This command only works if the database container is currently stopped, and uses `sudo` since the db uses a non-default user to store its data.