### PR TITLE
Include formatting imports.

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
-      - uses: axel-op/googlejavaformat-action@v3
+      - uses: axel-op/googlejavaformat-action@master
         with:
           skipCommit: true
-          args: "--skip-sorting-imports --replace"
       - name: show diff
         run: git add .; git diff --exit-code HEAD

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The client should be as simple as is practical to implement the desired user exp
 
 Java code should conform to the Google Java [styleguide](https://google.github.io/styleguide/javaguide.html). The project makes use of a linter and autoformatter for Java to help with this.
 
-We have an autoformatter if there isn't one in your IDE - just run `bin/fmt` and your code should be automatically formatted.
+We have an autoformatter for java code, if there isn't one in your IDE - just run `bin/fmt` and your code should be automatically formatted.
 
 Prefer using immutable collection types provided by [Guava](https://github.com/google/guava) ([API docs](https://guava.dev/releases/snapshot/api/docs/)) over the Java standard library's mutable collections unless impractical. Include a comment justifying the use of a mutable collection if you use one.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The client should be as simple as is practical to implement the desired user exp
 
 Java code should conform to the Google Java [styleguide](https://google.github.io/styleguide/javaguide.html). The project makes use of a linter and autoformatter for Java to help with this.
 
+We have an autoformatter if there isn't one in your IDE - just run `bin/fmt` and your code should be automatically formatted.
+
 Prefer using immutable collection types provided by [Guava](https://github.com/google/guava) ([API docs](https://guava.dev/releases/snapshot/api/docs/)) over the Java standard library's mutable collections unless impractical. Include a comment justifying the use of a mutable collection if you use one.
 
 #### Separation of concerns

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,15 +1,15 @@
 #! /bin/bash
-if ! docker image inspect uat:latest > /dev/null; then
-	echo "did not find uat image locally - going to build it."
+if ! docker image inspect fmt:latest > /dev/null; then
+	echo "did not find fmt image locally - going to build it."
 	if [ $(basename "$PWD") == "universal-application-tool-0.0.1" ]; then
-		docker build -t uat ../
+		docker build -t fmt -f formatter.Dockerfile ../
 	else
-		docker built -t uat ./
+		docker build -t fmt -f formatter.Dockerfile ./
 	fi
 fi
 
 if [ $(basename "$PWD") == "universal-application-tool-0.0.1" ]; then
-	docker run --rm -it -v "${PWD}/:/code" uat sbt javafmtAll
+	docker run --rm -it -v "${PWD}/:/code" fmt
 else
-	docker run --rm -it -v "${PWD}/universal-application-tool-0.0.1/:/code" uat sbt javafmtAll
+	docker run --rm -it -v "${PWD}/universal-application-tool-0.0.1/:/code" fmt
 fi

--- a/formatter.Dockerfile
+++ b/formatter.Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:slim
+RUN apt-get update
+RUN apt-get install -y wget
+RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar -O /fmt.jar
+VOLUME /code
+CMD ["sh", "-c", "java -jar /fmt.jar --replace $(find /code -name '*.java')"]

--- a/universal-application-tool-0.0.1/app/Module.java
+++ b/universal-application-tool-0.0.1/app/Module.java
@@ -1,6 +1,5 @@
 import com.google.inject.AbstractModule;
 import java.time.Clock;
-
 import services.ApplicationTimer;
 import services.AtomicCounter;
 import services.Counter;

--- a/universal-application-tool-0.0.1/app/controllers/AsyncController.java
+++ b/universal-application-tool-0.0.1/app/controllers/AsyncController.java
@@ -1,19 +1,17 @@
 package controllers;
 
 import akka.actor.ActorSystem;
-import javax.inject.*;
-
 import akka.actor.Scheduler;
-import play.*;
-import play.mvc.*;
-import java.util.concurrent.Executor;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-
+import javax.inject.*;
+import play.*;
+import play.mvc.*;
 import scala.concurrent.ExecutionContext;
-import scala.concurrent.duration.Duration;
 import scala.concurrent.ExecutionContextExecutor;
+import scala.concurrent.duration.Duration;
 
 /**
  * This controller contains an action that demonstrates how to write simple asynchronous code in a

--- a/universal-application-tool-0.0.1/app/controllers/CountController.java
+++ b/universal-application-tool-0.0.1/app/controllers/CountController.java
@@ -1,11 +1,10 @@
 package controllers;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import play.mvc.Controller;
 import play.mvc.Result;
 import services.Counter;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 /**
  * This controller demonstrates how to use dependency injection to bind a component into a

--- a/universal-application-tool-0.0.1/app/controllers/HomeController.java
+++ b/universal-application-tool-0.0.1/app/controllers/HomeController.java
@@ -1,10 +1,8 @@
 package controllers;
 
-import play.mvc.*;
-
-import views.html.*;
-
 import javax.inject.Inject;
+import play.mvc.*;
+import views.html.*;
 
 /** This controller contains an action to handle HTTP requests to the application's home page. */
 public class HomeController extends Controller {

--- a/universal-application-tool-0.0.1/app/filters/ExampleFilter.java
+++ b/universal-application-tool-0.0.1/app/filters/ExampleFilter.java
@@ -1,11 +1,10 @@
 package filters;
 
-import play.mvc.EssentialAction;
-import play.mvc.EssentialFilter;
-
+import java.util.concurrent.Executor;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.concurrent.Executor;
+import play.mvc.EssentialAction;
+import play.mvc.EssentialFilter;
 
 /** This is a simple filter that adds a header to all requests. */
 @Singleton

--- a/universal-application-tool-0.0.1/project/plugins.sbt
+++ b/universal-application-tool-0.0.1/project/plugins.sbt
@@ -1,3 +1,2 @@
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")

--- a/universal-application-tool-0.0.1/test/BrowserTest.java
+++ b/universal-application-tool-0.0.1/test/BrowserTest.java
@@ -1,11 +1,11 @@
+import static org.junit.Assert.assertTrue;
+import static play.test.Helpers.*;
+
 import org.junit.Test;
 import play.Application;
 import play.test.Helpers;
 import play.test.TestBrowser;
 import play.test.WithBrowser;
-
-import static org.junit.Assert.assertTrue;
-import static play.test.Helpers.*;
 
 public class BrowserTest extends WithBrowser {
 

--- a/universal-application-tool-0.0.1/test/FunctionalTest.java
+++ b/universal-application-tool-0.0.1/test/FunctionalTest.java
@@ -1,9 +1,9 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
 import controllers.AssetsFinder;
 import org.junit.Test;
 import play.test.WithApplication;
 import play.twirl.api.Content;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A functional test starts a Play application for every test.

--- a/universal-application-tool-0.0.1/test/UnitTest.java
+++ b/universal-application-tool-0.0.1/test/UnitTest.java
@@ -1,15 +1,14 @@
-import akka.actor.ActorSystem;
-import controllers.AsyncController;
-import controllers.CountController;
-import org.junit.Test;
-import play.mvc.Result;
-import scala.concurrent.ExecutionContextExecutor;
-
-import java.util.concurrent.CompletionStage;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static play.test.Helpers.contentAsString;
+
+import akka.actor.ActorSystem;
+import controllers.AsyncController;
+import controllers.CountController;
+import java.util.concurrent.CompletionStage;
+import org.junit.Test;
+import play.mvc.Result;
+import scala.concurrent.ExecutionContextExecutor;
 
 /**
  * Unit testing does not require Play application start up.


### PR DESCRIPTION
This PR revises the rules for formatting to include sorted imports, sorts existing imports, and switches from using an sbt plugin to using the google java formatter directly in a docker container.  This gives us more control.  `bin/fmt` continues to work correctly.