### PR TITLE
Store the password and secret key in secrets manager

### DIFF
--- a/bin/deploy-prod
+++ b/bin/deploy-prod
@@ -11,8 +11,6 @@ TIMESTAMP=$(date +%s)
 # which has the side effect of recreating all the containers.
 # That's kind of messy.  We'd prefer to use a secret manager.  We'll set that up next.
 DBUSERNAME=uat
-DBPASSWORD=$(openssl rand -base64 32 | tr -d '/')
-SECRETKEY=$(openssl rand -base64 32)
 
 aws s3 sync ./infra s3://seattle-uat-cftmpl/${TIMESTAMP}
-aws cloudformation update-stack --stack-name uat --template-url  https://seattle-uat-cftmpl.s3-us-west-2.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"DBUsername\", \"ParameterValue\": \"$DBUSERNAME\"}, {\"ParameterKey\": \"DBPassword\", \"ParameterValue\": \"$DBPASSWORD\"}, {\"ParameterKey\": \"SecretKey\", \"ParameterValue\": \"$SECRETKEY\"}, {\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}]"
+aws cloudformation update-stack --stack-name uat --template-url  https://seattle-uat-cftmpl.s3-us-west-2.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}]"

--- a/bin/deploy-prod
+++ b/bin/deploy-prod
@@ -7,10 +7,6 @@ docker tag universal-application-tool:latest public.ecr.aws/t1q6b4h2/universal-a
 docker push public.ecr.aws/t1q6b4h2/universal-application-tool:latest
 
 TIMESTAMP=$(date +%s)
-# Note that this updates the username and password for the database on each deploy
-# which has the side effect of recreating all the containers.
-# That's kind of messy.  We'd prefer to use a secret manager.  We'll set that up next.
-DBUSERNAME=uat
 
 aws s3 sync ./infra s3://seattle-uat-cftmpl/${TIMESTAMP}
 aws cloudformation update-stack --stack-name uat --template-url  https://seattle-uat-cftmpl.s3-us-west-2.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}]"

--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -30,16 +30,12 @@ Parameters:
       characters.
   DBPassword:
     NoEcho: 'true'
-    Description: Password database access
+    Description: Password for database access
     Type: String
-    MinLength: '8'
-    MaxLength: '64'
   SecretKey:
     NoEcho: 'true'
     Description: Secret key for Play application
     Type: String
-    MinLength: '12'
-    MaxLength: '64'
 Resources:
   ecscluster:
     Type: AWS::ECS::Cluster
@@ -98,9 +94,9 @@ Resources:
             - Name: DB_USERNAME
               Value: !Ref 'DBUsername'
             - Name: DB_PASSWORD
-              Value: !Ref 'DBPassword'
+              Value: !Sub '{{resolve:secretsmanager:${DBPassword}}}'
             - Name: SECRET_KEY
-              Value: !Ref 'SecretKey'
+              Value: !Sub '{{resolve:secretsmanager:${SecretKey}}}'
           Cpu: 1024
           Memory: 8192
           PortMappings:

--- a/infra/database.yaml
+++ b/infra/database.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ''
 Parameters:
+  DBPassword:
+    NoEcho: 'true'
+    Description: Password for database access
+    Type: String
   DBUsername:
     NoEcho: 'true'
     Description: Username for database access
@@ -10,12 +14,6 @@ Parameters:
     AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
     ConstraintDescription: must begin with a letter and contain only alphanumeric
       characters.
-  DBPassword:
-    NoEcho: 'true'
-    Description: Password database access
-    Type: String
-    MinLength: '8'
-    MaxLength: '64'
   PrivateSubnet1:
     Description: The private subnets to add the database to.
     Type: AWS::EC2::Subnet::Id
@@ -43,7 +41,7 @@ Resources:
       Engine: postgres
       EngineVersion: '12.5'
       MasterUsername: !Ref 'DBUsername'
-      MasterUserPassword: !Ref 'DBPassword'
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${DBPassword}}}'
       DBSubnetGroupName: !Ref 'subnetgroup'
       VPCSecurityGroups:
         - !Ref 'DBSecurityGroup'

--- a/infra/secrets.yaml
+++ b/infra/secrets.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ''
+Resources:
+  password:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: databasepassword
+      Description: "This is the password for the database, shared with the container."
+      GenerateSecretString:
+        PasswordLength: 40
+        ExcludeCharacters: '"@/\'
+  secretkey:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: secretkey
+      Description: "This is the secret key for the application."
+      GenerateSecretString:
+        PasswordLength: 40
+Outputs:
+  Key:
+    Description: The secret key for the application
+    Value: !Ref secretkey
+    Export:
+      Name: !Sub '${AWS::StackName}-key'
+  Password:
+    Description: The password for the database
+    Value: !Ref password
+    Export:
+      Name: !Sub '${AWS::StackName}-pwd'

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -1,27 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: ''
 Parameters:
-  DBUsername:
-    NoEcho: 'true'
-    Description: Username for database access
-    Type: String
-    MinLength: '1'
-    MaxLength: '16'
-    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
-    ConstraintDescription: must begin with a letter and contain only alphanumeric
-      characters.
-  DBPassword:
-    NoEcho: 'true'
-    Description: Password for database access
-    Type: String
-    MinLength: '16'
-    MaxLength: '64'
-  SecretKey:
-    NoEcho: 'true'
-    Description: Secret key for Play application
-    Type: String
-    MinLength: '12'
-    MaxLength: '64'
   Timestamp:
     Description: Current timestamp in seconds.
     Type: Number
@@ -30,6 +9,10 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/network.yaml'
+  Secrets:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/secrets.yaml'
   SecurityGroups:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -50,8 +33,8 @@ Resources:
     Properties:
       TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/database.yaml'
       Parameters:
-        DBUsername: !Ref 'DBUsername'
-        DBPassword: !Ref 'DBPassword'
+        DBUsername: uat
+        DBPassword: !GetAtt 'Secrets.Outputs.Password'
         DBSecurityGroup: !GetAtt 'SecurityGroups.Outputs.DatabaseGroup'
         PrivateSubnet1: !GetAtt 'VPC.Outputs.PrivateSubnet1'
         PrivateSubnet2: !GetAtt 'VPC.Outputs.PrivateSubnet2'
@@ -60,11 +43,11 @@ Resources:
     Properties:
       TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/containers.yaml'
       Parameters:
-        DBUsername: !Ref 'DBUsername'
-        DBPassword: !Ref 'DBPassword'
+        DBUsername: uat
+        DBPassword: !GetAtt 'Secrets.Outputs.Password'
         DBAddress: !GetAtt 'DB.Outputs.DBAddress'
         DBPort: !GetAtt 'DB.Outputs.DBPort'
-        SecretKey: !Ref 'SecretKey'
+        SecretKey: !GetAtt 'Secrets.Outputs.Key'
         PrivateSubnet1: !GetAtt 'VPC.Outputs.PrivateSubnet1'
         PrivateSubnet2: !GetAtt 'VPC.Outputs.PrivateSubnet2'
         LBTargetName: !GetAtt 'LB.Outputs.LBTarget'

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -4,6 +4,10 @@ Parameters:
   Timestamp:
     Description: Current timestamp in seconds.
     Type: Number
+  DBUsername:
+    Description: The name of the database user.
+    Type: String
+    Default: uat
 Resources:
   VPC:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Formerly we were generating these things client-side, which meant we altered the password and secret key on every redeploy - this stores and generates them server-side which is much more appropriate.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)