### PR TITLE
Add container autoscaling based on CPU utilization

### DIFF
--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -113,3 +113,25 @@ Resources:
               awslogs-region: us-west-2
               awslogs-stream-prefix: uatsrv
           Essential: true
+  autoscalingtarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MinCapacity: 2
+      MaxCapacity: 5
+      ResourceId: !Join ['/', [service, !Ref ecscluster, !GetAtt ecsservice.Name]]
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      RoleARN: # This is where the ARN of the SLR goes.
+  autoscalingpolict:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: UATAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref autoscalingtarget
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        ScaleInCooldown: 10
+        ScaleOutCooldown: 10
+        # Keep things at or lower than 75% CPU utilization
+        TargetValue: 75

--- a/infra/containers.yaml
+++ b/infra/containers.yaml
@@ -121,8 +121,8 @@ Resources:
       ResourceId: !Join ['/', [service, !Ref ecscluster, !GetAtt ecsservice.Name]]
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
-      RoleARN: # This is where the ARN of the SLR goes.
-  autoscalingpolict:
+      RoleARN: arn:aws:iam::405662711265:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService
+  autoscalingpolicy:
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
       PolicyName: UATAutoScalingPolicy


### PR DESCRIPTION
### Description
Targets 75% CPU utilization, scales up to 5 containers, or down to 2.  Fewer than 2 would be bad because it leaves the entire application down with a single failure, and higher than 5 is just unlikely.  Might increase that number for launch / public announcement?

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
