### PR TITLE
Turn off database logSql

### DIFF
--- a/universal-application-tool-0.0.1/conf/application.conf
+++ b/universal-application-tool-0.0.1/conf/application.conf
@@ -346,7 +346,7 @@ db {
 
   # You can turn on SQL logging for any datasource
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
-  default.logSql=true
+  default.logSql=false
 }
 
 # prod overrides - if environment variables exist, use them!


### PR DESCRIPTION
### Description
Turn off database logSql to avoid confusion in test output. This should be fine since we use Ebean to manage our database interaction.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
