### PR TITLE
Add monitoring to ELB and DB, add alert channels, do not populate them.

### DIFF
--- a/infra/database.yaml
+++ b/infra/database.yaml
@@ -56,3 +56,8 @@ Outputs:
     Value: !GetAtt 'postgresdb.Endpoint.Address'
     Export:
       Name: !Sub '${AWS::StackName}-DBAddress'
+  DBName:
+    Description: The name of the database
+    Value: !Ref postgresdb
+    Export:
+      Name: !Sub '${AWS::StackName}-DBName'

--- a/infra/load_balancer.yaml
+++ b/infra/load_balancer.yaml
@@ -80,3 +80,13 @@ Outputs:
     Value: !Ref 'lbtarget'
     Export:
       Name: !Sub '${AWS::StackName}-LBTarget'
+  TGFullName:
+    Description: Full name of the load balancer target group.
+    Value: !GetAtt 'lbtarget.TargetGroupFullName'
+    Export:
+      Name: !Sub '${AWS::StackName}-TGFullName'
+  LBFullName:
+    Description: Full name of the load balancer.
+    Value: !GetAtt 'publiclb.LoadBalancerFullName'
+    Export:
+      Name: !Sub '${AWS::StackName}-LBFullName'

--- a/infra/monitoring.yaml
+++ b/infra/monitoring.yaml
@@ -50,6 +50,9 @@ Resources:
             Metric:
               MetricName: HTTPCode_Target_2XX_Count
               Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
             Period: 60
             Stat: Sum
           ReturnData: false
@@ -58,6 +61,9 @@ Resources:
             Metric:
               MetricName: HTTPCode_Target_3XX_Count
               Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
             Period: 60
             Stat: Sum
           ReturnData: false
@@ -66,6 +72,9 @@ Resources:
             Metric:
               MetricName: HTTPCode_Target_5XX_Count
               Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
             Period: 60
             Stat: Sum
           ReturnData: false

--- a/infra/monitoring.yaml
+++ b/infra/monitoring.yaml
@@ -186,7 +186,7 @@ Resources:
       EvaluationPeriods: 3
       Threshold: 85
       AlarmActions:
-        - !Ref pagingalerts
+        - !Ref ticketalerts
       Metrics:
         - Id: dbcpu
           MetricStat:
@@ -210,7 +210,7 @@ Resources:
       EvaluationPeriods: 5
       Threshold: 5120
       AlarmActions:
-        - !Ref pagingalerts
+        - !Ref ticketalert
       Metrics:
         - Id: dbspace
           MetricStat:

--- a/infra/monitoring.yaml
+++ b/infra/monitoring.yaml
@@ -1,0 +1,225 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ''
+Parameters:
+  DBName:
+    Type: String
+    Description: The database to alert on.
+  LBName:
+    Type: String
+    Description: The ELB to alert on.
+  LBTGName:
+    Type: String
+    Description: The ELB TargetGroup to alert on.
+
+Resources:
+  # Alerts that do not require paging - shouldn't interrupt someone or wake them up.
+  ticketalerts:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: UATTicketAlerts
+      DisplayName: UATTicketAlerts
+  # Alerts that require immediate action and may indicate that the site is down.
+  # We want to get someone out of bed for this.
+  pagingalerts:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: UATPagingAlerts
+      DisplayName: UATPagingAlerts
+
+  # Send a page if more than 5% of requests are 500-range errors.
+  # This probably means that the website is seriously broken for a large percentage
+  # of users.
+  5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Too many 5xx on the live site detected.
+      AlarmName: 5xxErrorsTooHigh
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: ignore
+      EvaluationPeriods: 5
+      # Is this too sensitive?  we'll have to see.
+      Threshold: 0.05
+      AlarmActions:
+        - !Ref pagingalerts
+      Metrics:
+        - Id: ratio
+          Expression: (total5xx / (total2xx + total3xx + total5xx))
+          ReturnData: true
+        - Id: total2xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_2XX_Count
+              Namespace: AWS/ApplicationELB
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total3xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_3XX_Count
+              Namespace: AWS/ApplicationELB
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total5xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_5XX_Count
+              Namespace: AWS/ApplicationELB
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+
+  # Send a ticket if more than 1% of requests are 400-range errors.
+  # This probably means there's a broken link somewhere on the site,
+  # either inbound or internal.
+  4xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Too many 4xx on the live site - broken link?
+      AlarmName: 4xxErrorsTooHigh
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: ignore
+      EvaluationPeriods: 20
+      Threshold: 0.01
+      AlarmActions:
+        - !Ref ticketalerts
+      Metrics:
+        - Id: ratio
+          Expression: (total4xx / (total2xx + total3xx + total4xx))
+          ReturnData: true
+        - Id: total2xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_2XX_Count
+              Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total3xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_3XX_Count
+              Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total4xx
+          MetricStat:
+            Metric:
+              MetricName: HTTPCode_Target_4XX_Count
+              Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref LBName
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+
+  # Send a page if there are no healthy containers - this probably means something is
+  # very broken and it might be impossible to reach the app.
+  NoHealthyContainersAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: No healthy servers - site down.
+      AlarmName: SiteIsDownAlarm
+      ComparisonOperator: LessThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      TreatMissingData: breaching
+      Threshold: 0
+      AlarmActions:
+        - !Ref pagingalerts
+      Metrics:
+        - Id: healthyhosts
+          MetricStat:
+            Metric:
+              MetricName: HealthyHostCount
+              Namespace: AWS/ApplicationELB
+              Dimensions:
+                - Name: TargetGroup
+                  Value: !Ref LBTGName
+                - Name: LoadBalancer
+                  Value: !Ref LBName
+            Period: 60
+            Stat: Maximum
+          ReturnData: true
+
+
+  # Send a page if the database registers zero connections - this probably means
+  # that networking is down.
+  NoDBConnectionsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: No database connections - site likely nonfunctional.
+      AlarmName: DBConnectionsDownAlarm
+      ComparisonOperator: LessThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Threshold: 0
+      AlarmActions:
+        - !Ref pagingalerts
+      Metrics:
+        - Id: dbconns
+          MetricStat:
+            Metric:
+              MetricName: DatabaseConnections
+              Namespace: AWS/RDS
+              Dimensions:
+                - Name: DBInstanceIdentifier
+                  Value: !Ref DBName
+            Period: 60
+            Stat: Maximum
+          ReturnData: true
+
+  # Send a ticket if the database has very high CPU utilization
+  DBCPUTooHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Database CPU is overtaxed - site may be slow.
+      AlarmName: DBRunningHot
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 3
+      Threshold: 85
+      AlarmActions:
+        - !Ref pagingalerts
+      Metrics:
+        - Id: dbcpu
+          MetricStat:
+            Metric:
+              MetricName: CPUUtilization
+              Namespace: AWS/RDS
+              Dimensions:
+                - Name: DBInstanceIdentifier
+                  Value: !Ref DBName
+            Period: 60
+            Stat: Average
+          ReturnData: true
+
+  # Send a ticket if the database has less than 5GB free space
+  DBSpaceLowAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Database running low on storage space - site may go down soon if usage is high.
+      AlarmName: DBStorageSpaceLow
+      ComparisonOperator: LessThanOrEqualToThreshold
+      EvaluationPeriods: 5
+      Threshold: 5120
+      AlarmActions:
+        - !Ref pagingalerts
+      Metrics:
+        - Id: dbspace
+          MetricStat:
+            Metric:
+              MetricName: FreeStorageSpace
+              Namespace: AWS/RDS
+              Dimensions:
+                - Name: DBInstanceIdentifier
+                  Value: !Ref DBName
+            Period: 60
+            Stat: Maximum
+          ReturnData: true

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -56,3 +56,11 @@ Resources:
         PrivateSubnet2: !GetAtt 'VPC.Outputs.PrivateSubnet2'
         LBTargetName: !GetAtt 'LB.Outputs.LBTarget'
         ContainerSecurityGroup: !GetAtt 'SecurityGroups.Outputs.ContainerGroup'
+  Monitoring:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/monitoring.yaml'
+      Parameters:
+        DBName: !GetAtt 'DB.Outputs.DBName'
+        LBName: !GetAtt 'LB.Outputs.LBFullName'
+        LBTGName: !GetAtt 'LB.Outputs.TGFullName'


### PR DESCRIPTION
### Description
This adds a handful of alerts, described in comments in the file.

Page on:
* no db connections
* no healthy containers
* 5xx > 5%

Send ticket on:
* lots of 4xxs
* db free space low
* db cpu usage high

This doesn't actually hook up any sms or email or pager hooks, but you can do that in the UI - also we don't want those until we're live anyway.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
