### PR TITLE
Access applicant data through ApplicantData class initialized by ebean Applicant entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/project/
 logs/
 target/
 RUNNING_PID

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -31,7 +31,10 @@ public class Applicant extends BaseModel {
   }
 
   public ApplicantData getApplicantData() {
-    if (object == null) this.object = EMPTY_APPLICANT_DATA_JSON;
+    if (object == null) {
+      System.out.println("****** object == null ******");
+      this.object = EMPTY_APPLICANT_DATA_JSON;
+    }
 
     if (this.applicantData == null) {
       DocumentContext context = JsonPath.parse(object);

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -4,19 +4,24 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import io.ebean.annotation.DbJson;
 import java.io.IOException;
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.PrePersist;
+import javax.persistence.Table;
+
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
 
-@Entity
 /** The ebean mapped class that represents an individual applicant */
+@Entity
 @Table(name = "applicants")
 public class Applicant extends BaseModel {
   private static final long serialVersionUID = 1L;
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
   private ApplicantData applicantData;
 
-  @Constraints.Required @DbJson private String object;
+  @Constraints.Required
+  @DbJson
+  private String object;
 
   public ApplicantData getApplicantData() {
     if (object == null) {

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -5,7 +5,6 @@ import com.jayway.jsonpath.JsonPath;
 import io.ebean.annotation.DbJson;
 import java.io.IOException;
 import javax.persistence.*;
-
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
 

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -1,5 +1,7 @@
 package models;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import io.ebean.annotation.DbJsonB;
 import io.ebean.text.json.EJson;
 import java.io.IOException;
@@ -7,6 +9,8 @@ import java.util.Map;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
+import com.jayway.jsonpath.internal.JsonContext;
+import services.applicant.ApplicantData;
 
 @Entity
 /** The ebeans mapped class that represents an individual applicant */
@@ -14,22 +18,28 @@ import play.data.validation.Constraints;
 public class Applicant extends BaseModel {
   private static final long serialVersionUID = 1L;
 
-  public Map<String, Object> getObject() {
+  public Applicant() {
+    super();
+
+    this.object = "{ \"applicant\": {}, \"metadata\": {} }";
+  }
+
+  public String getObject() {
     return object;
   }
 
-  public void setObject(Map<String, Object> object) {
+  public void setObject(String object) {
     this.object = object;
   }
 
-  @Constraints.Required @DbJsonB
-  // When we build an object that Jackson can deserialize, we replace Map<String, Object> with that
-  // type.
-  // For now, this will be automatically deserialized - with subobjects being "Map<String, Object>"
-  // and lists being List<Object>.
-  Map<String, Object> object;
+  @Constraints.Required String object;
+
+  public ApplicantData getApplicantData() {
+    DocumentContext context = JsonPath.parse(getObject());
+    return new ApplicantData(context);
+  }
 
   public String objectAsJsonString() throws IOException {
-    return EJson.write(object);
+    return getApplicantData().asJsonString();
   }
 }

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -4,8 +4,8 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import io.ebean.annotation.DbJson;
 import java.io.IOException;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
 
@@ -19,20 +19,8 @@ public class Applicant extends BaseModel {
 
   @Constraints.Required @DbJson private String object;
 
-  @Override
-  public void save() {
-    try {
-      this.object = objectAsJsonString();
-    } catch (IOException err) {
-      throw new RuntimeException(err);
-    }
-
-    super.save();
-  }
-
   public ApplicantData getApplicantData() {
     if (object == null) {
-      System.out.println("****** object == null ******");
       this.object = EMPTY_APPLICANT_DATA_JSON;
     }
 
@@ -42,6 +30,11 @@ public class Applicant extends BaseModel {
     }
 
     return applicantData;
+  }
+
+  @PrePersist
+  public void synchronizeObject() throws IOException {
+    this.object = objectAsJsonString();
   }
 
   private String objectAsJsonString() throws IOException {

--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import javax.persistence.Entity;
 import javax.persistence.PrePersist;
 import javax.persistence.Table;
-
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
 
@@ -19,9 +18,7 @@ public class Applicant extends BaseModel {
   private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
   private ApplicantData applicantData;
 
-  @Constraints.Required
-  @DbJson
-  private String object;
+  @Constraints.Required @DbJson private String object;
 
   public ApplicantData getApplicantData() {
     if (object == null) {

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -12,10 +12,12 @@ public class ApplicantData {
     this.jsonData = checkNotNull(jsonData);
   }
 
+  @Deprecated
   public void put(String path, String key, String value) {
     this.jsonData.put(path, key, value);
   }
 
+  @Deprecated
   public <T> T read(String path, Class<T> type) {
     return this.jsonData.read(path, type);
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -12,12 +12,10 @@ public class ApplicantData {
     this.jsonData = checkNotNull(jsonData);
   }
 
-  @Deprecated
   public void put(String path, String key, String value) {
     this.jsonData.put(path, key, value);
   }
 
-  @Deprecated
   public <T> T read(String path, Class<T> type) {
     return this.jsonData.read(path, type);
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -1,0 +1,26 @@
+package services.applicant;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.jayway.jsonpath.DocumentContext;
+
+public class ApplicantData {
+
+  private DocumentContext jsonData;
+
+  public ApplicantData(DocumentContext jsonData) {
+    this.jsonData = checkNotNull(jsonData);
+  }
+
+  public void put(String path, String key, String value) {
+    this.jsonData.put(path, key, value);
+  }
+
+  public <T> T read(String path, Class<T> type) {
+    return this.jsonData.read(path, type);
+  }
+
+  public String asJsonString() {
+    return this.jsonData.jsonString();
+  }
+}

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -7,6 +7,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       guice,
       javaJdbc,
+      // JSON libraries
+      "com.jayway.jsonpath" % "json-path" % "2.5.0",
+
       // Database and database testing libraries
       "org.postgresql" % "postgresql" % "42.2.18",
       "org.testcontainers" % "postgresql" % "1.15.1" % Test,

--- a/universal-application-tool-0.0.1/package-lock.json
+++ b/universal-application-tool-0.0.1/package-lock.json
@@ -1,23 +1,8 @@
 {
   "name": "universal-application-tool-0.0.1",
   "version": "0.0.1",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "version": "0.0.1",
-      "license": "CC0-1.0",
-      "devDependencies": {
-        "@tsconfig/recommended": "^1.0.1"
-      }
-    },
-    "node_modules/@tsconfig/recommended": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.1.tgz",
-      "integrity": "sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==",
-      "dev": true
-    }
-  },
   "dependencies": {
     "@tsconfig/recommended": {
       "version": "1.0.1",

--- a/universal-application-tool-0.0.1/test/models/ApplicantTest.java
+++ b/universal-application-tool-0.0.1/test/models/ApplicantTest.java
@@ -1,0 +1,32 @@
+package models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import repository.ApplicantRepository;
+import services.applicant.ApplicantData;
+import org.junit.Test;
+import repository.WithPostgresContainer;
+
+public class ApplicantTest extends WithPostgresContainer {
+
+  @Test
+  public void hasAJsonDocumentContextWhenCreated() {
+    Applicant applicant = new Applicant();
+    assertThat(applicant.getApplicantData()).isInstanceOf(ApplicantData.class);
+  }
+
+  @Test
+  public void persistsChangesToTheDocumentContext() {
+    ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
+    Applicant applicant = new Applicant();
+
+    String path = "$.applicant";
+    applicant.getApplicantData().put(path, "birthDate", "1/1/2021");
+    applicant.save();
+
+    applicant = repo.lookupApplicant(applicant.id).toCompletableFuture().join().get();
+
+    assertThat(applicant.getApplicantData().read("$.applicant.birthDate", String.class))
+        .isEqualTo("Alice");
+  }
+}

--- a/universal-application-tool-0.0.1/test/models/ApplicantTest.java
+++ b/universal-application-tool-0.0.1/test/models/ApplicantTest.java
@@ -31,7 +31,7 @@ public class ApplicantTest extends WithPostgresContainer {
   }
 
   @Test
-  public void onlyCreatesOneApplicantData() {
+  public void createsOnlyOneApplicantData() {
     Applicant applicant = new Applicant();
 
     ApplicantData applicantData = applicant.getApplicantData();

--- a/universal-application-tool-0.0.1/test/models/ApplicantTest.java
+++ b/universal-application-tool-0.0.1/test/models/ApplicantTest.java
@@ -2,21 +2,21 @@ package models;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import repository.ApplicantRepository;
-import services.applicant.ApplicantData;
 import org.junit.Test;
+import repository.ApplicantRepository;
 import repository.WithPostgresContainer;
+import services.applicant.ApplicantData;
 
 public class ApplicantTest extends WithPostgresContainer {
 
   @Test
-  public void hasAJsonDocumentContextWhenCreated() {
+  public void hasAnApplicantDataWhenCreated() {
     Applicant applicant = new Applicant();
     assertThat(applicant.getApplicantData()).isInstanceOf(ApplicantData.class);
   }
 
   @Test
-  public void persistsChangesToTheDocumentContext() {
+  public void persistsChangesToTheApplicantData() {
     ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
     Applicant applicant = new Applicant();
 
@@ -27,6 +27,15 @@ public class ApplicantTest extends WithPostgresContainer {
     applicant = repo.lookupApplicant(applicant.id).toCompletableFuture().join().get();
 
     assertThat(applicant.getApplicantData().read("$.applicant.birthDate", String.class))
-        .isEqualTo("Alice");
+        .isEqualTo("1/1/2021");
+  }
+
+  @Test
+  public void onlyCreatesOneApplicantData() {
+    Applicant applicant = new Applicant();
+
+    ApplicantData applicantData = applicant.getApplicantData();
+
+    assertThat(applicant.getApplicantData() == applicantData);
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -19,9 +19,7 @@ public class ApplicantRepositoryTest extends WithPostgresContainer {
 
     Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
     assertThat(a.id).isEqualTo(1L);
-    System.out.println("******HERE******");
-    System.out.println(a.getApplicantData().asJsonString());
-    //    assertThat(a.getApplicantData().read("$.applicant.birthDate", String.class))
-    //        .isEqualTo("1/1/2021");
+    assertThat(a.getApplicantData().read("$.applicant.birthDate", String.class))
+        .isEqualTo("1/1/2021");
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -1,25 +1,27 @@
 package repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
+import models.Applicant;
 import org.junit.Test;
 
 public class ApplicantRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void createApplicant() {
-    //    // arrange
-    //    ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
-    //    Applicant applicant = new Applicant();
-    //    applicant.id = 1L;
-    //    applicant.setObject(
-    //        ImmutableMap.of("nestedObject", ImmutableMap.of("foo", "bar"), "secondKey", "value"));
-    //
-    //    // act
-    //    repo.insertApplicant(applicant).toCompletableFuture().join();
-    //
-    //    // assert
-    //    Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
-    //    assertThat(a.id).isEqualTo(1L);
-    //    assertThat(a.getObject()).containsAllEntriesOf(applicant.getObject());
+    ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
+    Applicant applicant = new Applicant();
+    applicant.id = 1L;
+    String path = "$.applicant";
+    applicant.getApplicantData().put(path, "birthDate", "1/1/2021");
+
+    repo.insertApplicant(applicant).toCompletableFuture().join();
+
+    Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
+    assertThat(a.id).isEqualTo(1L);
+    System.out.println("******HERE******");
+    System.out.println(a.getApplicantData().asJsonString());
+    //    assertThat(a.getApplicantData().read("$.applicant.birthDate", String.class))
+    //        .isEqualTo("1/1/2021");
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -11,14 +11,14 @@ public class ApplicantRepositoryTest extends WithPostgresContainer {
   public void createApplicant() {
     ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
     Applicant applicant = new Applicant();
-    applicant.id = 1L;
+    applicant.id = 2L;
     String path = "$.applicant";
     applicant.getApplicantData().put(path, "birthDate", "1/1/2021");
 
     repo.insertApplicant(applicant).toCompletableFuture().join();
 
-    Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
-    assertThat(a.id).isEqualTo(1L);
+    Applicant a = repo.lookupApplicant(2L).toCompletableFuture().join().get();
+    assertThat(a.id).isEqualTo(2L);
     assertThat(a.getApplicantData().read("$.applicant.birthDate", String.class))
         .isEqualTo("1/1/2021");
   }

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -10,17 +10,19 @@ public class ApplicantRepositoryTest extends WithPostgresContainer {
 
   @Test
   public void createApplicant() {
-    // arrange
-    final ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
-    Applicant applicant = new Applicant();
-    applicant.id = 1L;
-    applicant.setObject(
-        ImmutableMap.of("nestedObject", ImmutableMap.of("foo", "bar"), "secondKey", "value"));
-    // act
-    repo.insertApplicant(applicant).toCompletableFuture().join();
-    // assert
-    Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
-    assertThat(a.id).isEqualTo(1L);
-    assertThat(a.getObject()).containsAllEntriesOf(applicant.getObject());
+    //    // arrange
+    //    ApplicantRepository repo = app.injector().instanceOf(ApplicantRepository.class);
+    //    Applicant applicant = new Applicant();
+    //    applicant.id = 1L;
+    //    applicant.setObject(
+    //        ImmutableMap.of("nestedObject", ImmutableMap.of("foo", "bar"), "secondKey", "value"));
+    //
+    //    // act
+    //    repo.insertApplicant(applicant).toCompletableFuture().join();
+    //
+    //    // assert
+    //    Applicant a = repo.lookupApplicant(1L).toCompletableFuture().join().get();
+    //    assertThat(a.id).isEqualTo(1L);
+    //    assertThat(a.getObject()).containsAllEntriesOf(applicant.getObject());
   }
 }

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -1,9 +1,6 @@
 package repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.ImmutableMap;
-import models.Applicant;
 import org.junit.Test;
 
 public class ApplicantRepositoryTest extends WithPostgresContainer {


### PR DESCRIPTION
### Description
Create ApplicantData class that abstracts the applicant entity stored in the database and add a way to access that ApplicantData through ebean Applicant entity.

Note that the ApplicantData class is very rough for now. We will add nicer methods that hide away the specifics of dealing with jsonpath types.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issues
Contributes to #100 
