### PR TITLE
Github action to validate correct configuration of cloudformation

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,6 +51,7 @@ jobs:
 
       - uses: mshick/add-pr-comment@v1
         if: failure() && contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        name: Send failure comment.
         with:
           message: |
             I noticed that you have created a PR which seems to contain a file that updates CloudFormation.
@@ -60,6 +61,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: mshick/add-pr-comment@v1
+        name: Send success comment.
         if: success() && contains(toJSON(steps.file_changes.outputs.files), 'infra/')
         with:
           message: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,4 +18,49 @@ jobs:
         # Confirm that we get a response on port 9000.
         run: while ! docker run --network host appropriate/curl -v -s --retry-max-time 180 --retry-connrefused http://localhost:9000/ ; do sleep 5; done
         timeout-minutes: 3
+  cloudformation:
+    runs-on: ubuntu-18.04 # for older version of awscli.
+    steps:
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+      - name: fail if created from a fork
+        if: contains(toJSON(steps.file_changes.outputs.files), 'infra/') && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "Sorry, you created this PR from a fork and therefore we don't have access to the secrets we need to run this test."
+          echo "We actually can't even post this as a comment to the GitHub PR, so you probably found this in the logs while trying to figure out what failed."
+          echo "This is for genuinely good security reasons - GitHub doesn't authorize PRs from forks to have access to secrets, but allows"
+          echo "access to any commits deemed 'safe enough' to push to the main repo."
+          echo
+          echo "To fix this issue, just push your branch to the main repo, close the PR that generated this error, and open another one."
+          echo "If that won't work for you for some reason, say because you are an OSS contributor who does not have collaborator perms on the repo,"
+          echo "you can run bin/deploy-prod and verify your changes for yourself in an AWS account that you have access to."
+          exit 1
+
+      - name: Checkout
+        if: contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        uses: actions/checkout@v2
+
+      - name: Run check-change.
+        if: contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        id: check_change
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.SESSION_TOKEN }}
+        run: bin/check-cfn-change
+
+      - uses: mshick/add-pr-comment@v1
+        if: contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        with:
+          message: |
+            I noticed that you have created a PR which seems to contain a file that updates CloudFormation.
+            The changes passed preliminary validation!
+
+            The following objects will be recreated (or conditionally recreated) - please take a look and make sure
+            this is correct before submitting your PR.
+
+            ```
+            ${{ steps.check_change.outputs.changes_msg }}
+            ```
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,7 +50,17 @@ jobs:
         run: bin/check-cfn-change
 
       - uses: mshick/add-pr-comment@v1
-        if: contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        if: failure() && contains(toJSON(steps.file_changes.outputs.files), 'infra/')
+        with:
+          message: |
+            I noticed that you have created a PR which seems to contain a file that updates CloudFormation.
+            The changes failed preliminary validation, with the following message.
+
+            > ${{ steps.check_change.outputs.failure_msg }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: mshick/add-pr-comment@v1
+        if: success() && contains(toJSON(steps.file_changes.outputs.files), 'infra/')
         with:
           message: |
             I noticed that you have created a PR which seems to contain a file that updates CloudFormation.
@@ -59,8 +69,6 @@ jobs:
             The following objects will be recreated (or conditionally recreated) - please take a look and make sure
             this is correct before submitting your PR.
 
-            ```
-            ${{ steps.check_change.outputs.changes_msg }}
-            ```
+            > ${{ steps.check_change.outputs.changes_msg }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/bin/check-cfn-change
+++ b/bin/check-cfn-change
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z "$GITHUB_EVENT_PATH" ]; then
+	PR_NUMBER=localrun-$USER
+else
+	PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")
+fi
+
+set -e
+
+TIMESTAMP=$(date +%s)
+
+echo "checking if a changeset exists already..."
+if aws cloudformation describe-change-set --region us-west-2  --change-set-name auto-changeset-pr-$PR_NUMBER  --stack-name uat > /dev/null; then
+	echo "deleting..."
+	aws cloudformation delete-change-set --region us-west-2  --change-set-name auto-changeset-pr-$PR_NUMBER  --stack-name uat
+	sleep 5
+fi
+
+aws s3 sync ./infra s3://seattle-uat-cftmpl/${TIMESTAMP}
+
+aws cloudformation create-change-set --region us-west-2 --include-nested-stacks --stack-name uat --change-set-name auto-changeset-pr-$PR_NUMBER --template-url  https://seattle-uat-cftmpl.s3-us-west-2.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}]"
+
+sleep 10
+
+set +e
+rm /tmp/message
+for csn in $(aws cloudformation describe-change-set --region us-west-2 --change-set-name auto-changeset-pr-$PR_NUMBER --stack-name uat | jq -r '.Changes[].ResourceChange.ChangeSetId') ; do
+	aws cloudformation describe-change-set --region us-west-2 --change-set-name $csn | jq '.Changes[] | if .ResourceChange.Replacement == "True" then .ResourceChange.LogicalResourceId else null end' | grep -v "null" >> /tmp/message
+done
+set -e
+
+echo "::set-output name=changes_msg::$(cat /tmp/message | jq -s -c '.')"

--- a/bin/check-cfn-change
+++ b/bin/check-cfn-change
@@ -21,12 +21,32 @@ aws s3 sync ./infra s3://seattle-uat-cftmpl/${TIMESTAMP}
 
 aws cloudformation create-change-set --region us-west-2 --include-nested-stacks --stack-name uat --change-set-name auto-changeset-pr-$PR_NUMBER --template-url  https://seattle-uat-cftmpl.s3-us-west-2.amazonaws.com/$TIMESTAMP/stack.yaml --parameters "[{\"ParameterKey\": \"Timestamp\", \"ParameterValue\": \"$TIMESTAMP\"}]"
 
-sleep 10
+sleep 5
+
+rootcs=$(aws cloudformation describe-change-set --region us-west-2 --change-set-name auto-changeset-pr-$PR_NUMBER --stack-name uat)
+while [ "$(echo "$rootcs" | jq -r '.Status')" == "CREATE_IN_PROGRESS" ]; do
+	echo "Still creating, waiting..."
+	sleep 10
+	rootcs=$(aws cloudformation describe-change-set --region us-west-2 --change-set-name auto-changeset-pr-$PR_NUMBER --stack-name uat)
+done
+
+
+rootcs=$(aws cloudformation describe-change-set --region us-west-2 --change-set-name auto-changeset-pr-$PR_NUMBER --stack-name uat)
+
+if [ "$(echo "$rootcs" | jq -r '.Status')" != "CREATE_COMPLETE" ]; then
+	echo "::set-output name=failure_msg::$(echo "$rootcs" | jq -r '.StatusReason')"
+	exit 1
+fi
 
 set +e
 rm /tmp/message
-for csn in $(aws cloudformation describe-change-set --region us-west-2 --change-set-name auto-changeset-pr-$PR_NUMBER --stack-name uat | jq -r '.Changes[].ResourceChange.ChangeSetId') ; do
-	aws cloudformation describe-change-set --region us-west-2 --change-set-name $csn | jq '.Changes[] | if .ResourceChange.Replacement == "True" then .ResourceChange.LogicalResourceId else null end' | grep -v "null" >> /tmp/message
+for csn in $(echo $rootcs | jq -r '.Changes[].ResourceChange.ChangeSetId') ; do
+	cs=$(aws cloudformation describe-change-set --region us-west-2 --change-set-name $csn)
+	echo "$cs" | jq '.Changes[] | if .ResourceChange.Replacement == "True" then .ResourceChange.LogicalResourceId else null end' | grep -v "null" >> /tmp/message
+	if [ "$(echo "$cs" | jq -r '.Status')" != "CREATE_COMPLETE" ]; then
+		echo "::set-output name=failure_msg::$(echo "$cs" | jq -r '.StatusReason')"
+		exit 1
+	fi
 done
 set -e
 

--- a/infra/monitoring.yaml
+++ b/infra/monitoring.yaml
@@ -219,7 +219,7 @@ Resources:
       EvaluationPeriods: 5
       Threshold: 5120
       AlarmActions:
-        - !Ref ticketalert
+        - !Ref ticketalerts
       Metrics:
         - Id: dbspace
           MetricStat:

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -23,6 +23,7 @@ Resources:
       TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/security_groups.yaml'
       Parameters:
         VPCId: !GetAtt 'VPC.Outputs.VPCId'
+        ABadParameterToTestWhetherValidationWorks: 'does it?'
   LB:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/infra/stack.yaml
+++ b/infra/stack.yaml
@@ -23,7 +23,6 @@ Resources:
       TemplateURL: !Sub 'https://s3.amazonaws.com/seattle-uat-cftmpl/${Timestamp}/security_groups.yaml'
       Parameters:
         VPCId: !GetAtt 'VPC.Outputs.VPCId'
-        ABadParameterToTestWhetherValidationWorks: 'does it?'
   LB:
     Type: AWS::CloudFormation::Stack
     Properties:


### PR DESCRIPTION
If you make a change to a file under `infra/`, we will create a CFN changeset, which we will check to see which resources will be replaced.  This will crash if your cfn configuration is invalid or would require permissions we don't have, but will succeed regardless of the impact of your change.

It does print the likely impact of the change, which might help to keep updates safe, but I'll also add some stack rules later to keep us from accidentally deleting the database, for instance.

Hopefully, you'll see the message on this PR, due to the dummy file - which I will remove after testing to show that it works.  There's a chance there will be some back-and-forth since we don't control the creds used here - they may be invalid for this sort of operation.  But it works on my fork: https://github.com/ndmckinley/universal-application-tool/pull/2#issuecomment-777107518

### Description
Please explain the changes you made here.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
