### PR TITLE
Make db dev a little easier - expose database on default port in dev mode.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
   db:
     image: postgres:12.5
     restart: always
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_PASSWORD: example
 


### PR DESCRIPTION
Now that we have a prod db that doesn't use docker-compose, we can trust this is just for dev and can expose the port for dev purposes.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
