### PR TITLE
Add bin/sbt which acts like regular SBT but runs in a docker container.

### DIFF
--- a/bin/sbt
+++ b/bin/sbt
@@ -1,5 +1,7 @@
 #! /bin/bash
 
-# allocate a tty for better test output even though not strictly needed.
+# find the right dir to mount.  this is a silly trick based on finding the directory this file is in,
+# moving up one dir, and printing the name of that directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
+# allocate a tty for better test output even though not strictly needed.
 docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $DIR/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 uat sbt $@

--- a/bin/sbt
+++ b/bin/sbt
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+# allocate a tty for better test output even though not strictly needed.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && cd .. && pwd )"
+docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -v $DIR/universal-application-tool-0.0.1:/usr/src/universal-application-tool-0.0.1 uat sbt $@


### PR DESCRIPTION
### Description
You might try putting this on your `PATH` so that you can just type `sbt`!  Acts just like SBT but it runs in the container so you don't have anything weird going on with SBT versions.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
