### PR TITLE
Add @Before truncate to WithPostgresContainer

### DIFF
--- a/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
+++ b/universal-application-tool-0.0.1/test/repository/WithPostgresContainer.java
@@ -3,10 +3,26 @@ package repository;
 import static play.test.Helpers.fakeApplication;
 
 import com.google.common.collect.ImmutableMap;
+import io.ebean.Ebean;
+import io.ebean.EbeanServer;
+import models.Applicant;
+import models.Person;
+import models.Program;
+import models.Question;
+import org.junit.Before;
 import play.Application;
+import play.db.ebean.EbeanConfig;
 import play.test.WithApplication;
 
 public class WithPostgresContainer extends WithApplication {
+
+  @Before
+  public void truncateTables() {
+    EbeanConfig config = app.injector().instanceOf(EbeanConfig.class);
+    EbeanServer server = Ebean.getServer(config.defaultServer());
+    server.truncate(Applicant.class, Person.class, Program.class, Question.class);
+  }
+
   protected Application provideApplication() {
     return fakeApplication(
         ImmutableMap.of(


### PR DESCRIPTION
Add @Before method to truncate the database in WithPostgresContainer.

Fixes test cases in `FunctionalTest` that rely on database state by explicitly inserting into the DB in each test.

### Description
Please explain the changes you made here.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #157 
