### PR TITLE
Setup correct java version in GitHub formatter check

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
-      - uses: axel-op/googlejavaformat-action@master
+      - uses: axel-op/googlejavaformat-action@v3
         with:
-          version: 1.9
           skipCommit: true
       - name: show diff
         run: git add .; git diff --exit-code HEAD

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2 # v2 minimum required
       - uses: axel-op/googlejavaformat-action@master
         with:
+          version: 1.9
           skipCommit: true
       - name: show diff
         run: git add .; git diff --exit-code HEAD

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
-      - uses: axel-op/googlejavaformat-action@v3
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11.0.10'
+      - uses: axel-op/googlejavaformat-action@latest
         with:
           skipCommit: true
       - name: show diff

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11.0.10'
-      - uses: axel-op/googlejavaformat-action@latest
+      - uses: axel-op/googlejavaformat-action@master
         with:
           skipCommit: true
       - name: show diff

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -86,10 +86,7 @@ public class ProgramServiceImpl implements ProgramService {
     int blockDefinitionIndex = getBlockDefinitionIndex(programDefinition, blockDefinitionId);
 
     BlockDefinition blockDefinition =
-        programDefinition
-            .blockDefinitions()
-            .get(blockDefinitionIndex)
-            .toBuilder()
+        programDefinition.blockDefinitions().get(blockDefinitionIndex).toBuilder()
             .setQuestionDefinitions(questionDefinitions)
             .build();
 
@@ -107,10 +104,7 @@ public class ProgramServiceImpl implements ProgramService {
     int blockDefinitionIndex = getBlockDefinitionIndex(programDefinition, blockDefinitionId);
 
     BlockDefinition blockDefinition =
-        programDefinition
-            .blockDefinitions()
-            .get(blockDefinitionIndex)
-            .toBuilder()
+        programDefinition.blockDefinitions().get(blockDefinitionIndex).toBuilder()
             .setHidePredicate(Optional.of(predicate))
             .build();
 
@@ -128,10 +122,7 @@ public class ProgramServiceImpl implements ProgramService {
     int blockDefinitionIndex = getBlockDefinitionIndex(programDefinition, blockDefinitionId);
 
     BlockDefinition blockDefinition =
-        programDefinition
-            .blockDefinitions()
-            .get(blockDefinitionIndex)
-            .toBuilder()
+        programDefinition.blockDefinitions().get(blockDefinitionIndex).toBuilder()
             .setOptionalPredicate(Optional.of(predicate))
             .build();
 
@@ -166,8 +157,7 @@ public class ProgramServiceImpl implements ProgramService {
         ImmutableList.copyOf(mutableBlockDefinitions);
 
     Program program =
-        programDefinition
-            .toBuilder()
+        programDefinition.toBuilder()
             .setBlockDefinitions(updatedBlockDefinitions)
             .build()
             .toProgram();

--- a/universal-application-tool-0.0.1/app/services/program/test/FakeProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/test/FakeProgramService.java
@@ -72,10 +72,7 @@ public class FakeProgramService implements ProgramService {
     int blockIndex = getIndexOfBlock(programToUpdate, blockDefinitionId);
 
     BlockDefinition updatedBlockDefinition =
-        programToUpdate
-            .blockDefinitions()
-            .get(blockIndex)
-            .toBuilder()
+        programToUpdate.blockDefinitions().get(blockIndex).toBuilder()
             .setQuestionDefinitions(questionDefinitions)
             .build();
 
@@ -91,10 +88,7 @@ public class FakeProgramService implements ProgramService {
     int blockIndex = getIndexOfBlock(programToUpdate, blockDefinitionId);
 
     BlockDefinition updatedBlockDefinition =
-        programToUpdate
-            .blockDefinitions()
-            .get(blockIndex)
-            .toBuilder()
+        programToUpdate.blockDefinitions().get(blockIndex).toBuilder()
             .setHidePredicate(Optional.of(predicate))
             .build();
 
@@ -110,10 +104,7 @@ public class FakeProgramService implements ProgramService {
     int blockIndex = getIndexOfBlock(programToUpdate, blockDefinitionId);
 
     BlockDefinition updatedBlockDefinition =
-        programToUpdate
-            .blockDefinitions()
-            .get(blockIndex)
-            .toBuilder()
+        programToUpdate.blockDefinitions().get(blockIndex).toBuilder()
             .setOptionalPredicate(Optional.of(predicate))
             .build();
 
@@ -157,8 +148,7 @@ public class FakeProgramService implements ProgramService {
     mutableBlockDefinitions.set(blockDefinitionIndex, blockDefinition);
 
     programDefinition =
-        programDefinition
-            .toBuilder()
+        programDefinition.toBuilder()
             .setBlockDefinitions(ImmutableList.copyOf(mutableBlockDefinitions))
             .build();
     this.programs.put(programDefinition.id(), programDefinition);


### PR DESCRIPTION
### Description
Make sure the Java formatter in GitHub uses the same version of JDK as our app (currently 11.0.10), so the formatter version is correctly selected (v1.9).

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

