### PR TITLE
remove sbt java auto fmt

### DIFF
--- a/universal-application-tool-0.0.1/project/plugins.sbt
+++ b/universal-application-tool-0.0.1/project/plugins.sbt
@@ -1,6 +1,5 @@
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "6.0.0")
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")
 addSbtPlugin("name.de-vries" % "sbt-typescript" % "2.6.2")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.11")


### PR DESCRIPTION
### Description
Because this produces format different from our `bin/fmt`. This happens every we run our dev server.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
