### PR TITLE
Create an admin account test client.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
+++ b/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
@@ -1,0 +1,38 @@
+package auth;
+
+import controllers.admin.routes;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.credentials.AnonymousCredentials;
+import org.pac4j.core.util.HttpActionHelper;
+
+public class FakeAdminClient extends IndirectClient {
+
+  private ProfileFactory profileFactory;
+
+  @Inject
+  public FakeAdminClient(ProfileFactory profileFactory) {
+    this.profileFactory = profileFactory;
+  }
+
+  @Override
+  protected void internalInit() {
+    defaultCredentialsExtractor(
+        (ctx, store) -> {
+          // Double check that we haven't been fooled into allowing this somehow.
+          if (!ctx.getServerName().equals("localhost")) {
+            throw new UnsupportedOperationException(
+                "You cannot create an admin unless you are running locally.");
+          }
+          return Optional.of(new AnonymousCredentials());
+        });
+    defaultAuthenticator(
+        (cred, ctx, store) -> cred.setUserProfile(profileFactory.createNewAdmin()));
+    defaultRedirectionActionBuilder(
+        (ctx, store) ->
+            Optional.of(
+                HttpActionHelper.buildRedirectUrlAction(
+                    ctx, routes.AdminProgramController.index().url())));
+  }
+}

--- a/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
+++ b/universal-application-tool-0.0.1/app/auth/FakeAdminClient.java
@@ -1,5 +1,6 @@
 package auth;
 
+import com.google.common.base.Preconditions;
 import controllers.admin.routes;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -13,7 +14,7 @@ public class FakeAdminClient extends IndirectClient {
 
   @Inject
   public FakeAdminClient(ProfileFactory profileFactory) {
-    this.profileFactory = profileFactory;
+    this.profileFactory = Preconditions.checkNotNull(profileFactory);
   }
 
   @Override
@@ -23,7 +24,7 @@ public class FakeAdminClient extends IndirectClient {
           // Double check that we haven't been fooled into allowing this somehow.
           if (!ctx.getServerName().equals("localhost")) {
             throw new UnsupportedOperationException(
-                "You cannot create an admin unless you are running locally.");
+                "You cannot create a fake admin unless you are running locally.");
           }
           return Optional.of(new AnonymousCredentials());
         });

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -21,13 +21,21 @@ public class ProfileFactory {
   }
 
   public UatProfileData createNewApplicant() {
-    UatProfileData p = new UatProfileData(clock);
-    p.init(dbContext);
-    p.addRole(Roles.ROLE_APPLICANT.toString());
-    return p;
+    return create(Roles.ROLE_APPLICANT);
   }
 
   public UatProfile wrapProfileData(UatProfileData p) {
     return new UatProfile(dbContext, httpContext, p);
+  }
+
+  public UatProfileData createNewAdmin() {
+      return create(Roles.ROLE_UAT_ADMIN);
+  }
+
+  private UatProfileData create(Roles role) {
+    UatProfileData p = new UatProfileData(clock);
+    p.init(dbContext);
+    p.addRole(role.toString());
+    return p;
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -29,7 +29,7 @@ public class ProfileFactory {
   }
 
   public UatProfileData createNewAdmin() {
-      return create(Roles.ROLE_UAT_ADMIN);
+    return create(Roles.ROLE_UAT_ADMIN);
   }
 
   private UatProfileData create(Roles role) {

--- a/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileFactory.java
@@ -24,12 +24,12 @@ public class ProfileFactory {
     return create(Roles.ROLE_APPLICANT);
   }
 
-  public UatProfile wrapProfileData(UatProfileData p) {
-    return new UatProfile(dbContext, httpContext, p);
-  }
-
   public UatProfileData createNewAdmin() {
     return create(Roles.ROLE_UAT_ADMIN);
+  }
+
+  public UatProfile wrapProfileData(UatProfileData p) {
+    return new UatProfile(dbContext, httpContext, p);
   }
 
   private UatProfileData create(Roles role) {

--- a/universal-application-tool-0.0.1/app/auth/Roles.java
+++ b/universal-application-tool-0.0.1/app/auth/Roles.java
@@ -7,6 +7,10 @@ public enum Roles {
   ROLE_PROGRAM_ADMIN("ROLE_PROGRAM_ADMIN");
 
   private final String roleName;
+  public static final String APPLICANT_AUTHORIZER = "applicant";
+  public static final String UAT_ADMIN_AUTHORIZER = "uatadmin";
+  public static final String TI_AUTHORIZER = "trustedintermediary";
+  public static final String PROGRAM_ADMIN_AUTHORIZER = "programadmin";
 
   Roles(String roleName) {
     this.roleName = roleName;

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import forms.ProgramForm;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Controller;
@@ -40,14 +41,17 @@ public class AdminProgramController extends Controller {
     this.formFactory = checkNotNull(formFactory);
   }
 
+  @Secure(authorizers = "uatadmin")
   public Result index() {
     return ok(listView.render(this.service.listProgramDefinitions()));
   }
 
+  @Secure(authorizers = "uatadmin")
   public Result newOne(Request request) {
     return ok(newOneView.render(request));
   }
 
+  @Secure(authorizers = "uatadmin")
   public Result create(Request request) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -2,6 +2,7 @@ package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.Roles;
 import forms.ProgramForm;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -41,17 +42,17 @@ public class AdminProgramController extends Controller {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = "uatadmin")
+  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
   public Result index() {
     return ok(listView.render(this.service.listProgramDefinitions()));
   }
 
-  @Secure(authorizers = "uatadmin")
+  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
   public Result newOne(Request request) {
     return ok(newOneView.render(request));
   }
 
-  @Secure(authorizers = "uatadmin")
+  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
   public Result create(Request request) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -122,12 +122,14 @@ public class SecurityModule extends AbstractModule {
     Config config = new Config();
     config.setClients(clients);
     config.addAuthorizer(
-        "programadmin", new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()));
+        Roles.PROGRAM_ADMIN_AUTHORIZER,
+        new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()));
     config.addAuthorizer(
-        "uatadmin", new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
+        Roles.UAT_ADMIN_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
     config.addAuthorizer(
-        "applicant", new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
-    config.addAuthorizer("intermediary", new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
+        Roles.APPLICANT_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
+    config.addAuthorizer(
+        Roles.TI_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
 
     config.setHttpActionAdapter(PlayHttpActionAdapter.INSTANCE);
     return config;

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -97,12 +97,20 @@ public class SecurityModule extends AbstractModule {
     return new ProfileFactory(clock, dbContext, httpContext);
   }
 
+  protected FakeAdminClient fakeAdminClient(ProfileFactory profileFactory) {
+    return new FakeAdminClient(profileFactory);
+  }
+
   @Provides
   @Singleton
-  protected Config provideConfig(GuestClient guestClient) {
+  protected Config provideConfig(GuestClient guestClient, FakeAdminClient fakeAdminClient) {
     // This must match the line in `routes` also.
     Clients clients = new Clients(baseUrl + routes.CallbackController.callback("GuestClient"));
-    clients.setClients(guestClient);
+    if (this.baseUrl.equals(DEV_BASE_URL)) {
+      clients.setClients(guestClient, fakeAdminClient);
+    } else {
+      clients.setClients(guestClient);
+    }
     PlayHttpActionAdapter.INSTANCE
         .getResults()
         .putAll(

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -1,8 +1,7 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.body;
-import static j2html.TagCreator.h1;
+import static j2html.TagCreator.*;
 
 import com.google.inject.Inject;
 import controllers.routes;
@@ -22,16 +21,25 @@ public class LoginForm extends BaseHtmlView {
   public Content render(Http.Request request, Optional<String> message) {
     ContainerTag bodyTag =
         body(
-            h1("Error: You are not logged in").withCondHidden(!message.orElse("").equals("login")),
-            h1("TODO: IDCS integration"),
-            h1("Or, continue as guest."),
-            redirectButton(
-                "guest", "Continue", routes.CallbackController.callback("GuestClient").url()));
-    if (request.host().equals("localhost")) {
+            div(
+                h1("Error: You are not logged in")
+                    .withCondHidden(!message.orElse("").equals("login")),
+                h1("TODO: IDCS integration")),
+            div(
+                h1("Or, continue as guest."),
+                redirectButton(
+                    "guest", "Continue", routes.CallbackController.callback("GuestClient").url())));
+    // "defense in depth", sort of - this client won't be present in production, and this button
+    // won't show up except when running locally.
+    if (request.host().startsWith("localhost:")) {
       bodyTag =
           bodyTag.with(
-              redirectButton(
-                  "guest", "Continue", routes.CallbackController.callback("GuestClient").url()));
+              div(
+                  h1("DEBUG MODE: BECOME ADMIN"),
+                  redirectButton(
+                      "admin",
+                      "Continue",
+                      routes.CallbackController.callback("FakeAdminClient").url())));
     }
     return layout.htmlContent(bodyTag);
   }

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -6,6 +6,7 @@ import static j2html.TagCreator.h1;
 
 import com.google.inject.Inject;
 import controllers.routes;
+import j2html.tags.ContainerTag;
 import java.util.Optional;
 import play.mvc.Http;
 import play.twirl.api.Content;
@@ -19,12 +20,19 @@ public class LoginForm extends BaseHtmlView {
   }
 
   public Content render(Http.Request request, Optional<String> message) {
-    return layout.htmlContent(
+    ContainerTag bodyTag =
         body(
             h1("Error: You are not logged in").withCondHidden(!message.orElse("").equals("login")),
             h1("TODO: IDCS integration"),
             h1("Or, continue as guest."),
             redirectButton(
-                "guest", "Continue", routes.CallbackController.callback("GuestClient").url())));
+                "guest", "Continue", routes.CallbackController.callback("GuestClient").url()));
+    if (request.host().equals("localhost")) {
+      bodyTag =
+          bodyTag.with(
+              redirectButton(
+                  "guest", "Continue", routes.CallbackController.callback("GuestClient").url()));
+    }
+    return layout.htmlContent(bodyTag);
   }
 }

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -1,7 +1,9 @@
 package views;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static j2html.TagCreator.*;
+import static j2html.TagCreator.body;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.h1;
 
 import com.google.inject.Inject;
 import controllers.routes;

--- a/universal-application-tool-0.0.1/app/views/LoginForm.java
+++ b/universal-application-tool-0.0.1/app/views/LoginForm.java
@@ -34,14 +34,13 @@ public class LoginForm extends BaseHtmlView {
     // "defense in depth", sort of - this client won't be present in production, and this button
     // won't show up except when running locally.
     if (request.host().startsWith("localhost:")) {
-      bodyTag =
-          bodyTag.with(
-              div(
-                  h1("DEBUG MODE: BECOME ADMIN"),
-                  redirectButton(
-                      "admin",
-                      "Continue",
-                      routes.CallbackController.callback("FakeAdminClient").url())));
+      bodyTag.with(
+          div(
+              h1("DEBUG MODE: BECOME ADMIN"),
+              redirectButton(
+                  "admin",
+                  "Continue",
+                  routes.CallbackController.callback("FakeAdminClient").url())));
     }
     return layout.htmlContent(bodyTag);
   }

--- a/universal-application-tool-0.0.1/test/app/BrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BrowserTest.java
@@ -1,7 +1,6 @@
 package app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static play.test.Helpers.fakeApplication;
 
@@ -78,10 +77,8 @@ public class BrowserTest extends WithBrowser {
     assertTrue(browser.pageSource().contains("403"));
   }
 
-
   @Test
   public void adminTestLogin() {
-    String baseUrl = "http://localhost:" + play.api.test.Helpers.testServerPort();
     goTo(routes.HomeController.loginForm(Optional.empty()));
     browser.$("#admin").click();
     // should be redirected to root.

--- a/universal-application-tool-0.0.1/test/app/BrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BrowserTest.java
@@ -1,6 +1,8 @@
 package app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static play.test.Helpers.fakeApplication;
 
 import auth.Roles;
@@ -71,6 +73,31 @@ public class BrowserTest extends WithBrowser {
     assertThat(browser.pageSource()).contains("GuestClient");
     assertThat(browser.pageSource()).contains("{\"created_time\":");
     assertThat(browser.pageSource()).contains(Roles.ROLE_APPLICANT.toString());
+
+    goTo(controllers.admin.routes.AdminProgramController.index());
+    assertTrue(browser.pageSource().contains("403"));
+  }
+
+
+  @Test
+  public void adminTestLogin() {
+    String baseUrl = "http://localhost:" + play.api.test.Helpers.testServerPort();
+    goTo(routes.HomeController.loginForm(Optional.empty()));
+    browser.$("#admin").click();
+    // should be redirected to root.
+    assertThat(browser.url()).isEmpty();
+    assertThat(browser.pageSource()).contains("Your new application is ready.");
+
+    goTo(routes.HomeController.secureIndex());
+    assertThat(browser.pageSource()).contains("You are logged in.");
+
+    goTo(routes.ProfileController.myProfile());
+    assertThat(browser.pageSource()).contains("FakeAdminClient");
+    assertThat(browser.pageSource()).contains("{\"created_time\":");
+    assertThat(browser.pageSource()).contains(Roles.ROLE_UAT_ADMIN.toString());
+
+    goTo(controllers.admin.routes.AdminProgramController.index());
+    assertTrue(browser.pageSource().contains("Programs"));
   }
 
   private void goTo(Call method) {


### PR DESCRIPTION
### Description
Lock down the admin endpoints to admin accounts, and provide a way for us to create and assume an admin role in testing.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)

Looking for a review from both @natsid and @AWBaumann - @natsid for security & @AWBaumann as an FYI for the admin flow.