### PR TITLE
Convert QuestionHelpText to ImmutableMap, unwrapping the unnecessary Optional.

### DIFF
--- a/universal-application-tool-0.0.1/app/forms/QuestionForm.java
+++ b/universal-application-tool-0.0.1/app/forms/QuestionForm.java
@@ -2,7 +2,6 @@ package forms;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import services.question.QuestionDefinition;
 import services.question.QuestionDefinitionBuilder;
 import services.question.QuestionType;
@@ -95,10 +94,10 @@ public class QuestionForm {
   public QuestionDefinitionBuilder getBuilder() {
     ImmutableMap<Locale, String> questionTextMap =
         questionText.isEmpty() ? ImmutableMap.of() : ImmutableMap.of(Locale.ENGLISH, questionText);
-    Optional<ImmutableMap<Locale, String>> questionHelpTextMap =
+    ImmutableMap<Locale, String> questionHelpTextMap =
         questionHelpText.isEmpty()
-            ? Optional.empty()
-            : Optional.of(ImmutableMap.of(Locale.ENGLISH, questionHelpText));
+            ? ImmutableMap.of()
+            : ImmutableMap.of(Locale.ENGLISH, questionHelpText);
     QuestionDefinitionBuilder builder =
         new QuestionDefinitionBuilder()
             .setQuestionType(QuestionType.valueOf(questionType))

--- a/universal-application-tool-0.0.1/app/models/Question.java
+++ b/universal-application-tool-0.0.1/app/models/Question.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableMap;
 import io.ebean.annotation.DbJsonB;
 import java.util.Locale;
-import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.PostLoad;
 import javax.persistence.PostPersist;
@@ -35,7 +34,7 @@ public class Question extends BaseModel {
 
   private @Constraints.Required @DbJsonB ImmutableMap<Locale, String> questionText;
 
-  private @DbJsonB ImmutableMap<Locale, String> questionHelpText;
+  private @Constraints.Required @DbJsonB ImmutableMap<Locale, String> questionHelpText;
 
   private @Constraints.Required String questionType;
 
@@ -49,7 +48,7 @@ public class Question extends BaseModel {
     name = questionDefinition.getName();
     description = questionDefinition.getDescription();
     questionText = questionDefinition.getQuestionText();
-    questionHelpText = questionDefinition.getQuestionHelpText().orElse(null);
+    questionHelpText = questionDefinition.getQuestionHelpText();
     questionType = questionDefinition.getQuestionType().toString();
   }
 
@@ -65,7 +64,7 @@ public class Question extends BaseModel {
     name = questionDefinition.getName();
     description = questionDefinition.getDescription();
     questionText = questionDefinition.getQuestionText();
-    questionHelpText = questionDefinition.getQuestionHelpText().orElse(null);
+    questionHelpText = questionDefinition.getQuestionHelpText();
     questionType = questionDefinition.getQuestionType().toString();
   }
 
@@ -82,7 +81,7 @@ public class Question extends BaseModel {
             .setPath(path)
             .setDescription(description)
             .setQuestionText(questionText)
-            .setQuestionHelpText(Optional.ofNullable(questionHelpText))
+            .setQuestionHelpText(questionHelpText)
             .setQuestionType(QuestionType.valueOf(questionType))
             .build();
   }

--- a/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/AddressQuestionDefinition.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 
 public class AddressQuestionDefinition extends QuestionDefinition {
@@ -14,7 +13,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(id, version, name, path, description, questionText, questionHelpText);
   }
 
@@ -24,7 +23,7 @@ public class AddressQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(version, name, path, description, questionText, questionHelpText);
   }
 

--- a/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/NameQuestionDefinition.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 
 public class NameQuestionDefinition extends QuestionDefinition {
@@ -14,7 +13,7 @@ public class NameQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(id, version, name, path, description, questionText, questionHelpText);
   }
 
@@ -24,7 +23,7 @@ public class NameQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(version, name, path, description, questionText, questionHelpText);
   }
 

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinition.java
@@ -15,7 +15,7 @@ public abstract class QuestionDefinition {
   private final String path;
   private final String description;
   private final ImmutableMap<Locale, String> questionText;
-  private final Optional<ImmutableMap<Locale, String>> questionHelpText;
+  private final ImmutableMap<Locale, String> questionHelpText;
 
   public QuestionDefinition(
       OptionalLong id,
@@ -24,7 +24,7 @@ public abstract class QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     this.id = id;
     this.version = version;
     this.name = checkNotNull(name);
@@ -40,7 +40,7 @@ public abstract class QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     this(OptionalLong.empty(), version, name, path, description, questionText, questionHelpText);
   }
 
@@ -97,19 +97,19 @@ public abstract class QuestionDefinition {
 
   /** Get the question help text for the given locale. */
   public String getQuestionHelpText(Locale locale) throws TranslationNotFoundException {
-    if (!this.questionHelpText.isPresent()) {
+    if (this.questionHelpText.isEmpty()) {
       return "";
     }
 
-    if (this.questionHelpText.get().containsKey(locale)) {
-      return this.questionHelpText.get().get(locale);
+    if (this.questionHelpText.containsKey(locale)) {
+      return this.questionHelpText.get(locale);
     }
 
     throw new TranslationNotFoundException(this.getPath(), locale);
   }
 
   /** Get the question help text for all locales. This is used for serialization. */
-  public Optional<ImmutableMap<Locale, String>> getQuestionHelpText() {
+  public ImmutableMap<Locale, String> getQuestionHelpText() {
     return this.questionHelpText;
   }
 

--- a/universal-application-tool-0.0.1/app/services/question/QuestionDefinitionBuilder.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionDefinitionBuilder.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 
 public class QuestionDefinitionBuilder {
@@ -13,7 +12,7 @@ public class QuestionDefinitionBuilder {
   private String path;
   private String description;
   private ImmutableMap<Locale, String> questionText;
-  private Optional<ImmutableMap<Locale, String>> questionHelpText;
+  private ImmutableMap<Locale, String> questionHelpText;
   private QuestionType questionType = QuestionType.TEXT;
 
   public QuestionDefinitionBuilder setId(long id) {
@@ -47,7 +46,7 @@ public class QuestionDefinitionBuilder {
   }
 
   public QuestionDefinitionBuilder setQuestionHelpText(
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     this.questionHelpText = questionHelpText;
     return this;
   }

--- a/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/question/TextQuestionDefinition.java
@@ -2,7 +2,6 @@ package services.question;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 
 public class TextQuestionDefinition extends QuestionDefinition {
@@ -14,7 +13,7 @@ public class TextQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(id, version, name, path, description, questionText, questionHelpText);
   }
 
@@ -24,7 +23,7 @@ public class TextQuestionDefinition extends QuestionDefinition {
       String path,
       String description,
       ImmutableMap<Locale, String> questionText,
-      Optional<ImmutableMap<Locale, String>> questionHelpText) {
+      ImmutableMap<Locale, String> questionHelpText) {
     super(version, name, path, description, questionText, questionHelpText);
   }
 

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -7,7 +7,6 @@ import static play.test.Helpers.contentAsString;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import models.Question;
 import org.junit.Before;
 import org.junit.Test;
@@ -150,7 +149,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
             .setPath("the.ultimate.question")
             .setQuestionText(
                 ImmutableMap.of(Locale.ENGLISH, "What is the answer to the ultimate question?"))
-            .setQuestionHelpText(Optional.empty())
+            .setQuestionHelpText(ImmutableMap.of())
             .setQuestionType(QuestionType.TEXT);
     Question question = new Question(builder.build());
     question.save();

--- a/universal-application-tool-0.0.1/test/forms/QuestionFormTest.java
+++ b/universal-application-tool-0.0.1/test/forms/QuestionFormTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Test;
 import services.question.QuestionDefinition;
 import services.question.QuestionDefinitionBuilder;
@@ -35,7 +34,7 @@ public class QuestionFormTest {
             "my.question.path",
             "description",
             ImmutableMap.of(Locale.ENGLISH, "What is the question text?"),
-            Optional.empty());
+            ImmutableMap.of());
     QuestionDefinition actual = builder.build();
 
     assertThat(actual.isPersisted()).isFalse();

--- a/universal-application-tool-0.0.1/test/models/ProgramTest.java
+++ b/universal-application-tool-0.0.1/test/models/ProgramTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +37,7 @@ public class ProgramTest extends WithPostgresContainer {
             "applicant.name",
             "applicant's name",
             ImmutableMap.of(Locale.US, "What is your name?"),
-            Optional.empty());
+            ImmutableMap.of());
 
     BlockDefinition blockDefinition =
         BlockDefinition.builder()
@@ -87,7 +86,7 @@ public class ProgramTest extends WithPostgresContainer {
             "applicant.address",
             "applicant's address",
             ImmutableMap.of(Locale.US, "What is your address?"),
-            Optional.empty());
+            ImmutableMap.of());
     NameQuestionDefinition nameQuestionDefinition =
         new NameQuestionDefinition(
             OptionalLong.of(789L),
@@ -96,7 +95,7 @@ public class ProgramTest extends WithPostgresContainer {
             "applicant.name",
             "applicant's name",
             ImmutableMap.of(Locale.US, "What is your name?"),
-            Optional.empty());
+            ImmutableMap.of());
 
     BlockDefinition blockDefinition =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/test/models/QuestionTest.java
+++ b/universal-application-tool-0.0.1/test/models/QuestionTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import repository.QuestionRepository;
@@ -25,7 +24,7 @@ public class QuestionTest extends WithPostgresContainer {
   @Test
   public void canSaveQuestion() {
     QuestionDefinition definition =
-        new TextQuestionDefinition(1L, "test", "my.path", "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "test", "my.path", "", ImmutableMap.of(), ImmutableMap.of());
     Question question = new Question(definition);
 
     question.save();
@@ -38,7 +37,7 @@ public class QuestionTest extends WithPostgresContainer {
     assertThat(found.getQuestionDefinition().getPath()).isEqualTo("my.path");
     assertThat(found.getQuestionDefinition().getDescription()).isEqualTo("");
     assertThat(found.getQuestionDefinition().getQuestionText()).isEqualTo(ImmutableMap.of());
-    assertThat(found.getQuestionDefinition().getQuestionHelpText()).isEqualTo(Optional.empty());
+    assertThat(found.getQuestionDefinition().getQuestionHelpText()).isEqualTo(ImmutableMap.of());
   }
 
   @Test
@@ -50,7 +49,7 @@ public class QuestionTest extends WithPostgresContainer {
             "",
             "",
             ImmutableMap.of(Locale.ENGLISH, "hello"),
-            Optional.of(ImmutableMap.of(Locale.ENGLISH, "help")));
+            ImmutableMap.of(Locale.ENGLISH, "help"));
     Question question = new Question(definition);
 
     question.save();
@@ -60,13 +59,13 @@ public class QuestionTest extends WithPostgresContainer {
     assertThat(found.getQuestionDefinition().getQuestionText())
         .isEqualTo(ImmutableMap.of(Locale.ENGLISH, "hello"));
     assertThat(found.getQuestionDefinition().getQuestionHelpText())
-        .hasValue(ImmutableMap.of(Locale.ENGLISH, "help"));
+        .isEqualTo(ImmutableMap.of(Locale.ENGLISH, "help"));
   }
 
   @Test
   public void canSerializeDifferentQuestionTypes() {
     AddressQuestionDefinition address =
-        new AddressQuestionDefinition(1L, "address", "", "", ImmutableMap.of(), Optional.empty());
+        new AddressQuestionDefinition(1L, "address", "", "", ImmutableMap.of(), ImmutableMap.of());
     Question question = new Question(address);
 
     question.save();

--- a/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/QuestionRepositoryTest.java
@@ -62,7 +62,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
             "applicant.name",
             "applicant's name",
             ImmutableMap.of(Locale.US, "What is your name?"),
-            Optional.empty());
+            ImmutableMap.of());
     Question question = new Question(questionDefinition);
 
     repo.insertQuestion(question).toCompletableFuture().join();
@@ -81,7 +81,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
             "applicant.name",
             "applicant's name",
             ImmutableMap.of(Locale.US, "What is your name?"),
-            Optional.empty());
+            ImmutableMap.of());
     Question question = new Question(questionDefinition);
 
     repo.insertQuestionSync(question);
@@ -91,7 +91,7 @@ public class QuestionRepositoryTest extends WithPostgresContainer {
 
   private Question saveQuestion(String path) {
     QuestionDefinition definition =
-        new TextQuestionDefinition(1L, "", path, "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", path, "", ImmutableMap.of(), ImmutableMap.of());
     Question question = new Question(definition);
     question.save();
     return question;

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,7 +65,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
                     "my.path.name",
                     "description",
                     ImmutableMap.of(Locale.ENGLISH, "question?"),
-                    Optional.of(ImmutableMap.of(Locale.ENGLISH, "help text"))))
+                    ImmutableMap.of(Locale.ENGLISH, "help text")))
             .get();
   }
 

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -28,7 +28,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
           "applicant.name",
           "The name of the applicant.",
           ImmutableMap.of(Locale.US, "What is your name?"),
-          Optional.empty());
+          ImmutableMap.of());
 
   @Before
   public void setProgramServiceImpl() {
@@ -132,7 +132,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     "applicant.address",
                     "Applicant's address",
                     ImmutableMap.of(Locale.US, "What is your addess?"),
-                    Optional.empty()))
+                    ImmutableMap.of()))
             .get();
     QuestionDefinition questionThree =
         qs.create(
@@ -142,7 +142,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     "applicant.favcolor",
                     "Applicant's favorite color",
                     ImmutableMap.of(Locale.US, "Is orange your favorite color?"),
-                    Optional.empty()))
+                    ImmutableMap.of()))
             .get();
 
     ProgramDefinition programOne =

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -21,7 +21,7 @@ public class QuestionDefinitionTest {
             "my.path.name",
             "description",
             ImmutableMap.of(Locale.ENGLISH, "question?"),
-            Optional.of(ImmutableMap.of(Locale.ENGLISH, "help text")));
+            ImmutableMap.of(Locale.ENGLISH, "help text"));
 
     assertThat(question.getId()).isEqualTo(123L);
     assertThat(question.getVersion()).isEqualTo(1L);
@@ -36,7 +36,7 @@ public class QuestionDefinitionTest {
   public void getQuestionTextForUnknownLocale_throwsException() {
     String questionPath = "question.path";
     QuestionDefinition question =
-        new TextQuestionDefinition(1L, "", questionPath, "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", questionPath, "", ImmutableMap.of(), ImmutableMap.of());
 
     Throwable thrown = catchThrowable(() -> question.getQuestionText(Locale.FRANCE));
 
@@ -56,7 +56,7 @@ public class QuestionDefinitionTest {
             questionPath,
             "",
             ImmutableMap.of(),
-            Optional.of(ImmutableMap.of(Locale.ENGLISH, "help text")));
+            ImmutableMap.of(Locale.ENGLISH, "help text"));
 
     Throwable thrown = catchThrowable(() -> question.getQuestionHelpText(Locale.FRANCE));
 
@@ -69,14 +69,14 @@ public class QuestionDefinitionTest {
   @Test
   public void getEmptyHelpTextForUnknownLocale_succeeds() throws TranslationNotFoundException {
     QuestionDefinition question =
-        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
     assertThat(question.getQuestionHelpText(Locale.FRANCE)).isEqualTo("");
   }
 
   @Test
   public void newQuestionHasTypeText() {
     QuestionDefinition question =
-        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
 
     assertThat(question.getQuestionType()).isEqualTo(QuestionType.TEXT);
   }
@@ -84,7 +84,7 @@ public class QuestionDefinitionTest {
   @Test
   public void newQuestionHasStringScalar() {
     QuestionDefinition question =
-        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
     assertThat(question.getScalars()).containsOnly(entry("text", ScalarType.STRING));
     assertThat(question.getScalarType("text").get()).isEqualTo(ScalarType.STRING);
     assertThat(question.getScalarType("text").get().getClassFor().get()).isEqualTo(String.class);
@@ -94,7 +94,7 @@ public class QuestionDefinitionTest {
   public void newQuestionHasStringScalar_withFullPath() {
     QuestionDefinition question =
         new TextQuestionDefinition(
-            1L, "name", "path.to.question", "description", ImmutableMap.of(), Optional.empty());
+            1L, "name", "path.to.question", "description", ImmutableMap.of(), ImmutableMap.of());
     assertThat(question.getFullyQualifiedScalars())
         .containsOnly(entry("path.to.question.text", ScalarType.STRING));
     assertThat(question.getScalarType("text").get()).isEqualTo(ScalarType.STRING);
@@ -104,7 +104,7 @@ public class QuestionDefinitionTest {
   @Test
   public void newQuestionMissingScalar_returnsOptionalEmpty() {
     QuestionDefinition question =
-        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), Optional.empty());
+        new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
     assertThat(question.getScalarType("notPresent")).isEqualTo(Optional.empty());
   }
 }

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -21,7 +21,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
           "my.path.name",
           "description",
           ImmutableMap.of(Locale.ENGLISH, "question?"),
-          Optional.of(ImmutableMap.of(Locale.ENGLISH, "help text")));
+          ImmutableMap.of(Locale.ENGLISH, "help text"));
 
   @Before
   public void setProgramServiceImpl() {

--- a/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/ReadOnlyQuestionServiceImplTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalLong;
 import org.junit.Test;
 
@@ -21,7 +20,7 @@ public class ReadOnlyQuestionServiceImplTest {
           "applicant.name",
           "The name of the applicant",
           ImmutableMap.of(Locale.ENGLISH, "What is your name?"),
-          Optional.empty());
+          ImmutableMap.of());
   AddressQuestionDefinition addressQuestion =
       new AddressQuestionDefinition(
           OptionalLong.of(456L),
@@ -30,7 +29,7 @@ public class ReadOnlyQuestionServiceImplTest {
           "applicant.address",
           "The address of the applicant",
           ImmutableMap.of(Locale.ENGLISH, "What is your address?"),
-          Optional.empty());
+          ImmutableMap.of());
   QuestionDefinition basicQuestion =
       new TextQuestionDefinition(
           OptionalLong.of(789L),
@@ -39,7 +38,7 @@ public class ReadOnlyQuestionServiceImplTest {
           "applicant.favoriteColor",
           "The favorite color of the applicant",
           ImmutableMap.of(Locale.ENGLISH, "What is your favorite color?"),
-          Optional.empty());
+          ImmutableMap.of());
 
   private String invalidPath = "invalid.path";
 

--- a/universal-application-tool-0.0.1/test/support/ResourceFabricator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceFabricator.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
-import java.util.Optional;
 import models.Applicant;
 import models.Program;
 import play.inject.Injector;
@@ -43,7 +42,7 @@ public class ResourceFabricator {
                 "my.path.name",
                 "description",
                 ImmutableMap.of(Locale.ENGLISH, "question?"),
-                Optional.of(ImmutableMap.of(Locale.ENGLISH, "help text"))))
+                ImmutableMap.of(Locale.ENGLISH, "help text")))
         .get();
   }
 


### PR DESCRIPTION
### Description
It's not necessary to have an `Optional<ImmutableList>` so we're unwrapping it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
#237

### Follow ups
In order to close #237 we should implement `QuestionDefinition.getPreferredQuestionText()` and `QuestionDefinition.getPreferredQuestionHelpText()` that uses a global `preferredLocale` variable so we're not passing around `Locale.ENGLISH` everywhere.
