### PR TITLE
Add program block controllers and views, but no forms.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -1,51 +1,78 @@
 package controllers.admin;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+import javax.inject.Inject;
 import play.data.FormFactory;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
+import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import views.admin.ProgramBlockEditView;
 
-import javax.inject.Inject;
-
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class AdminProgramBlocksController extends Controller {
 
-    private final ProgramService service;
-    // private final ProgramBlockEditView blockEditView;
-    // private final FormFactory formFactory;
+  private final ProgramService service;
+  private final ProgramBlockEditView editView;
+  // private final FormFactory formFactory;
 
-    @Inject
-    public AdminProgramBlocksController(
-            ProgramService service,
-            ProgramBlockEditView blockEditView,
-            FormFactory formFactory) {
-        this.service = checkNotNull(service);
-        // this.blockEditView = checkNotNull(blockEditView);
-        // this.formFactory = checkNotNull(formFactory);
+  @Inject
+  public AdminProgramBlocksController(
+      ProgramService service, ProgramBlockEditView editView, FormFactory formFactory) {
+    this.service = checkNotNull(service);
+    this.editView = checkNotNull(editView);
+    // this.formFactory = checkNotNull(formFactory);
+  }
+
+  public Result index(long programId) {
+    Optional<ProgramDefinition> programMaybe = service.getProgramDefinition(programId);
+    if (programMaybe.isEmpty()) {
+      return notFound(String.format("Program ID %d not found.", programId));
     }
 
-    public Result index(long programId) {
-        Optional<ProgramDefinition> programMaybe = service.getProgramDefinition(programId);
-        if (programMaybe.isEmpty()) {
-            return notFound(String.format("Program ID %d not found.", programId));
-        }
-
-        ProgramDefinition program = programMaybe.get();
-        if (program.blockDefinitions().size() > 0) {
-            // routes.AdminProgramBlocksController.edit(pid, program.blockdefinitions.get(0).id())
-            return ok();
-        }
-
-        return redirect(routes.AdminProgramBlocksController.newOne(programId));
+    ProgramDefinition program = programMaybe.get();
+    if (program.blockDefinitions().size() == 0) {
+      return redirect(routes.AdminProgramBlocksController.create(programId));
     }
 
-    public Result newOne(Request request, long programId) {
-        return ok();
+    long blockId = program.blockDefinitions().get(program.blockDefinitions().size() - 1).id();
+    return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
+  }
+
+  public Result create(long programId) {
+    Optional<ProgramDefinition> programMaybe = service.getProgramDefinition(programId);
+    if (programMaybe.isEmpty()) {
+      return notFound(String.format("Program ID %d not found.", programId));
     }
+
+    ProgramDefinition program = programMaybe.get();
+    try {
+      program = service.addBlockToProgram(programId, "", "");
+    } catch (ProgramNotFoundException e) {
+      // This really shouldn't happen
+      return notFound(e.toString());
+    }
+    long blockId = program.blockDefinitions().get(program.blockDefinitions().size() - 1).id();
+    return redirect(routes.AdminProgramBlocksController.edit(programId, blockId).url());
+  }
+
+  public Result edit(Request request, long programId, long blockId) {
+    Optional<ProgramDefinition> programMaybe = service.getProgramDefinition(programId);
+    if (programMaybe.isEmpty()) {
+      return notFound(String.format("Program ID %d not found.", programId));
+    }
+    ProgramDefinition program = programMaybe.get();
+
+    Optional<BlockDefinition> blockMaybe = program.getBlockDefinition(blockId);
+    if (blockMaybe.isEmpty()) {
+      return notFound(String.format("Block ID %d not found for Program %d", blockId, programId));
+    }
+    BlockDefinition block = blockMaybe.get();
+
+    return ok(editView.render(request, program, block));
+  }
 }

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -17,8 +17,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class AdminProgramBlocksController extends Controller {
 
     private final ProgramService service;
-    private final ProgramBlockEditView blockEditView;
-    private final FormFactory formFactory;
+    // private final ProgramBlockEditView blockEditView;
+    // private final FormFactory formFactory;
 
     @Inject
     public AdminProgramBlocksController(
@@ -26,8 +26,8 @@ public class AdminProgramBlocksController extends Controller {
             ProgramBlockEditView blockEditView,
             FormFactory formFactory) {
         this.service = checkNotNull(service);
-        this.blockEditView = checkNotNull(blockEditView);
-        this.formFactory = checkNotNull(formFactory);
+        // this.blockEditView = checkNotNull(blockEditView);
+        // this.formFactory = checkNotNull(formFactory);
     }
 
     public Result index(long programId) {

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -1,0 +1,51 @@
+package controllers.admin;
+
+import play.data.FormFactory;
+import play.mvc.Controller;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import services.program.ProgramDefinition;
+import services.program.ProgramService;
+import views.admin.ProgramBlockEditView;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class AdminProgramBlocksController extends Controller {
+
+    private final ProgramService service;
+    private final ProgramBlockEditView blockEditView;
+    private final FormFactory formFactory;
+
+    @Inject
+    public AdminProgramBlocksController(
+            ProgramService service,
+            ProgramBlockEditView blockEditView,
+            FormFactory formFactory) {
+        this.service = checkNotNull(service);
+        this.blockEditView = checkNotNull(blockEditView);
+        this.formFactory = checkNotNull(formFactory);
+    }
+
+    public Result index(long programId) {
+        Optional<ProgramDefinition> programMaybe = service.getProgramDefinition(programId);
+        if (programMaybe.isEmpty()) {
+            return notFound(String.format("Program ID %d not found.", programId));
+        }
+
+        ProgramDefinition program = programMaybe.get();
+        if (program.blockDefinitions().size() > 0) {
+            // routes.AdminProgramBlocksController.edit(pid, program.blockdefinitions.get(0).id())
+            return ok();
+        }
+
+        return redirect(routes.AdminProgramBlocksController.newOne(programId));
+    }
+
+    public Result newOne(Request request, long programId) {
+        return ok();
+    }
+}

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -57,7 +57,7 @@ public class AdminProgramController extends Controller {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();
     service.createProgramDefinition(program.getName(), program.getDescription());
-    return found(routes.AdminProgramController.index());
+    return redirect(routes.AdminProgramController.index().url());
   }
 
   public Result edit(Request request, long id) {
@@ -74,7 +74,7 @@ public class AdminProgramController extends Controller {
     ProgramForm program = programForm.bindFromRequest(request).get();
     try {
       service.updateProgramDefinition(id, program.getName(), program.getDescription());
-      return found(routes.AdminProgramController.index());
+      return redirect(routes.AdminProgramController.index().url());
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", id));
     }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -3,6 +3,7 @@ package services.program;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import java.util.Optional;
 import models.Program;
 import services.question.QuestionDefinition;
 
@@ -25,6 +26,10 @@ public abstract class ProgramDefinition {
   @JsonIgnore
   public QuestionDefinition getQuestionDefinition(int blockIndex, int questionIndex) {
     return blockDefinitions().get(blockIndex).getQuestionDefinition(questionIndex);
+  }
+
+  public Optional<BlockDefinition> getBlockDefinition(long blockId) {
+    return blockDefinitions().stream().filter(b -> b.id() == blockId).findAny();
   }
 
   public Program toProgram() {

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -1,7 +1,6 @@
 package views.admin;
 
 import static j2html.TagCreator.body;
-import static j2html.TagCreator.h1;
 import static j2html.TagCreator.head;
 import static j2html.TagCreator.main;
 
@@ -11,15 +10,15 @@ import play.twirl.api.Content;
 import views.BaseHtmlLayout;
 import views.ViewUtils;
 
-public class AdminProgramLayout extends BaseHtmlLayout {
+public class AdminLayout extends BaseHtmlLayout {
 
   @Inject
-  public AdminProgramLayout(ViewUtils viewUtils) {
+  public AdminLayout(ViewUtils viewUtils) {
     super(viewUtils);
   }
 
-  /** Renders mainDomContents within the main tag, in the context of the applicant layout. */
+  /** Renders mainDomContents within the main tag, in the context of the admin layout. */
   protected Content render(DomContent... mainDomContents) {
-    return htmlContent(head(), body().with(h1("Program"), main(mainDomContents), tailwindStyles()));
+    return htmlContent(head(getCommonCssTag()), body(main(mainDomContents)));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -19,6 +19,6 @@ public class AdminLayout extends BaseHtmlLayout {
 
   /** Renders mainDomContents within the main tag, in the context of the admin layout. */
   protected Content render(DomContent... mainDomContents) {
-    return htmlContent(head(getCommonCssTag()), body(main(mainDomContents)));
+    return htmlContent(head(tailwindStyles(), getCommonCssTag()), body(main(mainDomContents)));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
+++ b/universal-application-tool-0.0.1/app/views/admin/AdminLayout.java
@@ -19,6 +19,6 @@ public class AdminLayout extends BaseHtmlLayout {
 
   /** Renders mainDomContents within the main tag, in the context of the admin layout. */
   protected Content render(DomContent... mainDomContents) {
-    return htmlContent(head(tailwindStyles(), getCommonCssTag()), body(main(mainDomContents)));
+    return htmlContent(head(tailwindStyles()), body(main(mainDomContents)));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
@@ -7,16 +7,21 @@ import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import views.BaseHtmlView;
 
-public class ProgramBlockEditView  extends BaseHtmlView {
-    private final AdminProgramLayout layout;
+public class ProgramBlockEditView extends BaseHtmlView {
 
-    @Inject
-    public ProgramBlockEditView(AdminProgramLayout layout) {
-        this.layout = layout;
-    }
+  private final AdminProgramLayout layout;
 
-    public Content render(Request request, ProgramDefinition program) { return layout.render(); }
+  @Inject
+  public ProgramBlockEditView(AdminProgramLayout layout) {
+    this.layout = layout;
+  }
+
+  public Content render(Request request, ProgramDefinition program) {
+    return layout.render();
+  }
 
 
-    public Content render(Request request, ProgramDefinition program, BlockDefinition block) { return layout.render(); }
+  public Content render(Request request, ProgramDefinition program, BlockDefinition block) {
+    return layout.render();
+  }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
@@ -1,0 +1,22 @@
+package views.admin;
+
+import com.google.inject.Inject;
+import play.mvc.Http.Request;
+import play.twirl.api.Content;
+import services.program.BlockDefinition;
+import services.program.ProgramDefinition;
+import views.BaseHtmlView;
+
+public class ProgramBlockEditView  extends BaseHtmlView {
+    private final AdminProgramLayout layout;
+
+    @Inject
+    public ProgramBlockEditView(AdminProgramLayout layout) {
+        this.layout = layout;
+    }
+
+    public Content render(Request request, ProgramDefinition program) { return layout.render(); }
+
+
+    public Content render(Request request, ProgramDefinition program, BlockDefinition block) { return layout.render(); }
+}

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramBlockEditView.java
@@ -1,5 +1,8 @@
 package views.admin;
 
+import static j2html.TagCreator.a;
+import static j2html.TagCreator.div;
+
 import com.google.inject.Inject;
 import play.mvc.Http.Request;
 import play.twirl.api.Content;
@@ -9,19 +12,19 @@ import views.BaseHtmlView;
 
 public class ProgramBlockEditView extends BaseHtmlView {
 
-  private final AdminProgramLayout layout;
+  private final AdminLayout layout;
 
   @Inject
-  public ProgramBlockEditView(AdminProgramLayout layout) {
+  public ProgramBlockEditView(AdminLayout layout) {
     this.layout = layout;
   }
 
-  public Content render(Request request, ProgramDefinition program) {
-    return layout.render();
-  }
-
-
   public Content render(Request request, ProgramDefinition program, BlockDefinition block) {
-    return layout.render();
+    return layout.render(
+        div(
+            a().withText("Add block")
+                .withHref(
+                    controllers.admin.routes.AdminProgramBlocksController.create(program.id())
+                        .url())));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramEditView.java
@@ -1,5 +1,6 @@
 package views.admin;
 
+import static j2html.TagCreator.a;
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.div;
 import static j2html.TagCreator.form;
@@ -34,6 +35,7 @@ public class ProgramEditView extends BaseHtmlView {
                     .withMethod("post")
                     .withAction(
                         controllers.admin.routes.AdminProgramController.update(program.id())
-                            .url()))));
+                            .url())),
+                div(a().withText("Manage Questions").withHref(controllers.admin.routes.AdminProgramBlocksController.index(program.id()).url()))));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramEditView.java
@@ -13,10 +13,10 @@ import services.program.ProgramDefinition;
 import views.BaseHtmlView;
 
 public class ProgramEditView extends BaseHtmlView {
-  private final AdminProgramLayout layout;
+  private final AdminLayout layout;
 
   @Inject
-  public ProgramEditView(AdminProgramLayout layout) {
+  public ProgramEditView(AdminLayout layout) {
     this.layout = layout;
   }
 
@@ -36,6 +36,10 @@ public class ProgramEditView extends BaseHtmlView {
                     .withAction(
                         controllers.admin.routes.AdminProgramController.update(program.id())
                             .url())),
-                div(a().withText("Manage Questions").withHref(controllers.admin.routes.AdminProgramBlocksController.index(program.id()).url()))));
+            div(
+                a().withText("Manage Questions")
+                    .withHref(
+                        controllers.admin.routes.AdminProgramBlocksController.index(program.id())
+                            .url()))));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramIndexView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramIndexView.java
@@ -16,10 +16,10 @@ import services.program.ProgramDefinition;
 import views.BaseHtmlView;
 
 public final class ProgramIndexView extends BaseHtmlView {
-  private final AdminProgramLayout layout;
+  private final AdminLayout layout;
 
   @Inject
-  public ProgramIndexView(AdminProgramLayout layout) {
+  public ProgramIndexView(AdminLayout layout) {
     this.layout = layout;
   }
 

--- a/universal-application-tool-0.0.1/app/views/admin/ProgramNewOneView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/ProgramNewOneView.java
@@ -11,10 +11,10 @@ import play.twirl.api.Content;
 import views.BaseHtmlView;
 
 public final class ProgramNewOneView extends BaseHtmlView {
-  private final AdminProgramLayout layout;
+  private final AdminLayout layout;
 
   @Inject
-  public ProgramNewOneView(AdminProgramLayout layout) {
+  public ProgramNewOneView(AdminLayout layout) {
     this.layout = layout;
   }
 

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -14,12 +14,17 @@ GET     /postgres                   controllers.PostgresController.index()
 POST    /postgres                   controllers.PostgresController.create(request: Request)
 POST    /postgresSync               controllers.PostgresController.createSync(request: Request)
 
-# A controller for a page for an admin to create a new application
-GET     /admin/programs             controllers.admin.AdminProgramController.index
-GET     /admin/programs/new         controllers.admin.AdminProgramController.newOne(request: Request)
-GET     /admin/programs/:id/edit    controllers.admin.AdminProgramController.edit(request: Request, id: Long)
-POST    /admin/programs/:id         controllers.admin.AdminProgramController.update(request: Request, id: Long)
-POST    /admin/programs             controllers.admin.AdminProgramController.create(request: Request)
+# A controller for pages for an admin to create and maintain programs
+GET     /admin/programs                    controllers.admin.AdminProgramController.index
+GET     /admin/programs/new                controllers.admin.AdminProgramController.newOne(request: Request)
+GET     /admin/programs/:programId/edit          controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
+POST    /admin/programs                    controllers.admin.AdminProgramController.create(request: Request)
+POST    /admin/programs/:programId               controllers.admin.AdminProgramController.update(request: Request, programId: Long)
+
+# A controller for pages for an admin to create and maintain blocks for a program
+GET     /admin/programs/:programId/blocks        controllers.admin.AdminProgramBlocksController.index(programId: Long)
+GET     /admin/programs/:programId/blocks/new    controllers.admin.AdminProgramBlocksController.newOne(request: Request, programId: Long)
+# GET     /admin/programs/:programId/blocks/:blockId/edit    controllers.admin.AdminProgramBlocksController.edit(request: Request, programId: Long, blockId: Long)
 
 # A controller for a page for an admin to view, edit, and create questions
 GET     /admin/questions             controllers.admin.QuestionController.index(renderAs: String ?= "table")

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -22,9 +22,9 @@ POST    /admin/programs                    controllers.admin.AdminProgramControl
 POST    /admin/programs/:programId               controllers.admin.AdminProgramController.update(request: Request, programId: Long)
 
 # A controller for pages for an admin to create and maintain blocks for a program
-GET     /admin/programs/:programId/blocks        controllers.admin.AdminProgramBlocksController.index(programId: Long)
-GET     /admin/programs/:programId/blocks/new    controllers.admin.AdminProgramBlocksController.newOne(request: Request, programId: Long)
-# GET     /admin/programs/:programId/blocks/:blockId/edit    controllers.admin.AdminProgramBlocksController.edit(request: Request, programId: Long, blockId: Long)
+GET     /admin/programs/:programId/blocks                    controllers.admin.AdminProgramBlocksController.index(programId: Long)
+GET     /admin/programs/:programId/blocks/new                controllers.admin.AdminProgramBlocksController.create(programId: Long)
+GET     /admin/programs/:programId/blocks/:blockId/edit      controllers.admin.AdminProgramBlocksController.edit(request: Request, programId: Long, blockId: Long)
 
 # A controller for a page for an admin to view, edit, and create questions
 GET     /admin/questions             controllers.admin.QuestionController.index(renderAs: String ?= "table")

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -17,9 +17,9 @@ POST    /postgresSync               controllers.PostgresController.createSync(re
 # A controller for pages for an admin to create and maintain programs
 GET     /admin/programs                    controllers.admin.AdminProgramController.index
 GET     /admin/programs/new                controllers.admin.AdminProgramController.newOne(request: Request)
-GET     /admin/programs/:programId/edit          controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
+GET     /admin/programs/:programId/edit    controllers.admin.AdminProgramController.edit(request: Request, programId: Long)
 POST    /admin/programs                    controllers.admin.AdminProgramController.create(request: Request)
-POST    /admin/programs/:programId               controllers.admin.AdminProgramController.update(request: Request, programId: Long)
+POST    /admin/programs/:programId         controllers.admin.AdminProgramController.update(request: Request, programId: Long)
 
 # A controller for pages for an admin to create and maintain blocks for a program
 GET     /admin/programs/:programId/blocks                    controllers.admin.AdminProgramBlocksController.index(programId: Long)

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -13,7 +13,6 @@ import play.mvc.Http;
 import play.mvc.Result;
 import repository.WithPostgresContainer;
 import services.program.BlockDefinition;
-import services.program.ProgramDefinition;
 
 public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
@@ -33,7 +32,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_withProgramWithNoBlocks_redirectsToCreate() {
-    Program program = insertProgram("program");
+    Program program = resourceFabricator().insertProgram("program");
 
     Result result = controller.index(program.id);
 
@@ -46,7 +45,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
   public void index_withProgramWithBlocks_redirectsToEdit() {
     BlockDefinition block =
         BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
-    Program program = insertProgram("program", block);
+    Program program = resourceFabricator().insertProgram("program", block);
 
     Result result = controller.index(program.id);
 
@@ -64,7 +63,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
   @Test
   public void create_withProgram_addsBlock() {
-    Program program = insertProgram("program");
+    Program program = resourceFabricator().insertProgram("program");
     Result result = controller.create(program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -79,7 +78,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
   public void create_withProgramWithBlock_addsBlock() {
     BlockDefinition block =
         BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
-    Program program = insertProgram("program", block);
+    Program program = resourceFabricator().insertProgram("program", block);
     Result result = controller.create(program.id);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
@@ -103,7 +102,7 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
     Http.Request request = fakeRequest().build();
     BlockDefinition block =
         BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
-    Program program = insertProgram("program", block);
+    Program program = resourceFabricator().insertProgram("program", block);
     Result result = controller.edit(request, program.id, 2L);
 
     assertThat(result.status()).isEqualTo(NOT_FOUND);
@@ -114,25 +113,9 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
     Http.Request request = fakeRequest().build();
     BlockDefinition block =
         BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
-    Program program = insertProgram("program", block);
+    Program program = resourceFabricator().insertProgram("program", block);
     Result result = controller.edit(request, program.id, 1L);
 
     assertThat(result.status()).isEqualTo(OK);
-  }
-
-  private static Program insertProgram(String name) {
-    Program program = new Program(name, "description");
-    program.save();
-    return program;
-  }
-
-  private static Program insertProgram(String name, BlockDefinition block) {
-    Program program = new Program(name, "description");
-    program.save();
-    ProgramDefinition programDefinition = program.getProgramDefinition();
-    programDefinition = programDefinition.toBuilder().addBlockDefinition(block).build();
-    program = programDefinition.toProgram();
-    program.update();
-    return program;
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -1,0 +1,138 @@
+package controllers.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static play.mvc.Http.Status.NOT_FOUND;
+import static play.mvc.Http.Status.OK;
+import static play.mvc.Http.Status.SEE_OTHER;
+import static play.test.Helpers.fakeRequest;
+
+import models.Program;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Http;
+import play.mvc.Result;
+import repository.WithPostgresContainer;
+import services.program.BlockDefinition;
+import services.program.ProgramDefinition;
+
+public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
+
+  private AdminProgramBlocksController controller;
+
+  @Before
+  public void setup() {
+    controller = instanceOf(AdminProgramBlocksController.class);
+  }
+
+  @Test
+  public void index_withInvalidProgram_notFound() {
+    Result result = controller.index(1L);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void index_withProgramWithNoBlocks_redirectsToCreate() {
+    Program program = insertProgram("program");
+
+    Result result = controller.index(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.create(program.id).url());
+  }
+
+  @Test
+  public void index_withProgramWithBlocks_redirectsToEdit() {
+    BlockDefinition block =
+        BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
+    Program program = insertProgram("program", block);
+
+    Result result = controller.index(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.edit(program.id, 1L).url());
+  }
+
+  @Test
+  public void create_withInvalidProgram_notFound() {
+    Result result = controller.create(1L);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void create_withProgram_addsBlock() {
+    Program program = insertProgram("program");
+    Result result = controller.create(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.edit(program.id, 1L).url());
+
+    program.refresh();
+    assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(1);
+  }
+
+  @Test
+  public void create_withProgramWithBlock_addsBlock() {
+    BlockDefinition block =
+        BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
+    Program program = insertProgram("program", block);
+    Result result = controller.create(program.id);
+
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
+    assertThat(result.redirectLocation())
+        .hasValue(routes.AdminProgramBlocksController.edit(program.id, 2L).url());
+
+    program.refresh();
+    assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(2);
+  }
+
+  @Test
+  public void edit_withInvalidProgram_notFound() {
+    Http.Request request = fakeRequest().build();
+    Result result = controller.edit(request, 1L, 1L);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void edit_withInvalidBlock_notFound() {
+    Http.Request request = fakeRequest().build();
+    BlockDefinition block =
+        BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
+    Program program = insertProgram("program", block);
+    Result result = controller.edit(request, program.id, 2L);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
+  }
+
+  @Test
+  public void edit_withProgramWithBlock_OK() {
+    Http.Request request = fakeRequest().build();
+    BlockDefinition block =
+        BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
+    Program program = insertProgram("program", block);
+    Result result = controller.edit(request, program.id, 1L);
+
+    assertThat(result.status()).isEqualTo(OK);
+  }
+
+  private static Program insertProgram(String name) {
+    Program program = new Program(name, "description");
+    program.save();
+    return program;
+  }
+
+  private static Program insertProgram(String name, BlockDefinition block) {
+    Program program = new Program(name, "description");
+    program.save();
+    ProgramDefinition programDefinition = program.getProgramDefinition();
+    programDefinition = programDefinition.toBuilder().addBlockDefinition(block).build();
+    program = programDefinition.toProgram();
+    program.update();
+    return program;
+  }
+}

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
@@ -16,7 +16,6 @@ import play.mvc.Http.RequestBuilder;
 import play.mvc.Result;
 import play.test.Helpers;
 import repository.WithPostgresContainer;
-import services.program.ProgramNotFoundException;
 import views.html.helper.CSRF;
 
 public class AdminProgramControllerTest extends WithPostgresContainer {
@@ -39,8 +38,8 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
   @Test
   public void index_returnsPrograms() {
-    insertProgram("one");
-    insertProgram("two");
+    resourceFabricator().insertProgram("one");
+    resourceFabricator().insertProgram("two");
 
     Result result = controller.index();
 
@@ -79,7 +78,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
   @Test
   public void create_includesNewAndExistingProgramsInList() {
-    insertProgram("Existing One");
+    resourceFabricator().insertProgram("Existing One");
     RequestBuilder requestBuilder =
         Helpers.fakeRequest()
             .bodyForm(
@@ -106,9 +105,9 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void edit_returnsExpectedForm() throws ProgramNotFoundException {
+  public void edit_returnsExpectedForm() {
     Request request = addCSRFToken(Helpers.fakeRequest()).build();
-    Program program = insertProgram("test program");
+    Program program = resourceFabricator().insertProgram("test program");
 
     Result result = controller.edit(request, program.id);
 
@@ -128,8 +127,8 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void update_overwritesExistingProgram() throws ProgramNotFoundException {
-    insertProgram("Existing One");
+  public void update_overwritesExistingProgram() {
+    resourceFabricator().insertProgram("Existing One");
     RequestBuilder requestBuilder =
         Helpers.fakeRequest()
             .bodyForm(
@@ -143,11 +142,5 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
     Result redirectResult = controller.index();
     assertThat(contentAsString(redirectResult)).contains("New Program");
     assertThat(contentAsString(redirectResult)).doesNotContain("Existing One");
-  }
-
-  private static Program insertProgram(String name) {
-    Program program = new Program(name, "description");
-    program.save();
-    return program;
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static play.api.test.CSRFTokenHelper.addCSRFToken;
 import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
-import static play.test.Helpers.FOUND;
+import static play.mvc.Http.Status.SEE_OTHER;
 import static play.test.Helpers.contentAsString;
 
 import com.google.common.collect.ImmutableMap;
@@ -69,7 +69,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
     Result result = controller.create(requestBuilder.build());
 
-    assertThat(result.status()).isEqualTo(FOUND);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
     Result redirectResult = controller.index();
@@ -87,7 +87,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
     Result result = controller.create(requestBuilder.build());
 
-    assertThat(result.status()).isEqualTo(FOUND);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
     Result redirectResult = controller.index();
@@ -137,7 +137,7 @@ public class AdminProgramControllerTest extends WithPostgresContainer {
 
     Result result = controller.update(requestBuilder.build(), 1L);
 
-    assertThat(result.status()).isEqualTo(FOUND);
+    assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation()).hasValue(routes.AdminProgramController.index().url());
 
     Result redirectResult = controller.index();

--- a/universal-application-tool-0.0.1/test/support/ResourceFabricator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceFabricator.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import models.Applicant;
 import models.Program;
 import play.inject.Injector;
+import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
 import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
@@ -73,5 +74,18 @@ public class ResourceFabricator {
 
   public <T> T instanceOf(Class<T> clazz) {
     return injector.instanceOf(clazz);
+  }
+
+  public Program insertProgram(String name, BlockDefinition block) {
+    Program program = new Program(name, "description");
+
+    program.save();
+
+    ProgramDefinition programDefinition =
+        program.getProgramDefinition().toBuilder().addBlockDefinition(block).build();
+    program = programDefinition.toProgram();
+    program.update();
+
+    return program;
   }
 }


### PR DESCRIPTION
### Description
Add button to /admin/programs/:id/edit to "manage questions". The button goes to "/admin/programs/:pid/blocks/index".

`index`, if there are blocks to show, redirects to `/admin/programs/:pid/blocks/:bid/edit` for the first block. If there are no blocks to index, redirects to `/admin/programs/:pid/blocks/create`.

`create` creates an empty block and redirects to `/admin/programs/:pid/blocks/:bid/edit` for the last (latest) block.

`edit` has nothing but a button that goes to `create`.

### UI
Manage questions button
![image](https://user-images.githubusercontent.com/12072571/109237575-aa373580-7786-11eb-9d84-ca0b2da837da.png)

Edit view is just an "add block" button.
![image](https://user-images.githubusercontent.com/12072571/109237602-b9b67e80-7786-11eb-8bae-db4a9a91dd5a.png)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
