### PR TITLE
Swap to alpine.  Ran and confirmed no changes on main.

### DIFF
--- a/formatter.Dockerfile
+++ b/formatter.Dockerfile
@@ -1,10 +1,8 @@
-FROM openjdk:slim
-RUN apt-get update
-RUN apt-get install -y wget
+FROM adoptopenjdk/openjdk11:alpine-slim
+RUN apk update
+RUN apk add --no-cache --update bash wget
 RUN wget https://github.com/google/google-java-format/releases/download/google-java-format-1.9/google-java-format-1.9-all-deps.jar -O /fmt.jar
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs npm
-RUN npm install -g npm@latest
+RUN apk add --update npm
 RUN npm install -g typescript typescript-formatter 
 VOLUME /code
 CMD ["sh", "-c", "java -jar /fmt.jar --replace $(find /code -name '*.java'); cd /code; npm install; tsfmt -r $(find /code/app -name '*.ts' -not -path '*node_modules*' -not -path '*node-modules*')"]


### PR DESCRIPTION
### Description
The formatter used to use a debian derived OS, which provided a different default version of NPM, which wrote incompatible lockfiles, since `tsfmt` actually reads and rewrites the lockfile.  Now we use the same version in `uat` and `fmt`.  This will fix the issue raised in https://github.com/seattle-uat/universal-application-tool/pull/259.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
