### PR TITLE
Ensure we always run the most up-to-date formatter.

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -1,4 +1,11 @@
 #! /bin/bash
+echo "Making sure we're up to date with the latest formatter..."
+if ! docker pull public.ecr.aws/t1q6b4h2/uat-formatter:latest; then
+	echo "Failed to pull - possibly some stuck credentials.  De-authenticating then retrying..."
+	docker logout https://public.ecr.aws/t1q6b4h2/uat-formatter
+	docker pull public.ecr.aws/t1q6b4h2/uat-formatter:latest
+fi
+
 if [ $(basename "$PWD") == "universal-application-tool-0.0.1" ]; then
 	docker run --rm -it -v "${PWD}/:/code" public.ecr.aws/t1q6b4h2/uat-formatter:latest
 else


### PR DESCRIPTION
### Description
Always pull the most up-to-date version of the formatter from AWS.

If you are logged in to AWS and have configured docker creds for the formatter, it might not let you pull the most up to date version because your creds are old.  However, if you have *no* creds, it works fine.  This just deletes your creds if they are not working.  All our creds are temporary so it's not too surprising that this would happen sometimes.  Should be harmless, never delete anything that's still working.
