### PR TITLE
Move ApplicantProgramBlocksController to new `controllers.applicant` package

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/applicant/ApplicantProgramBlocksController.java
@@ -1,4 +1,4 @@
-package controllers;
+package controllers.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/applicant/ApplicantProgramBlockEditView.java
@@ -7,6 +7,7 @@ import static j2html.TagCreator.h1;
 import static j2html.TagCreator.p;
 
 import com.google.inject.Inject;
+import controllers.applicant.routes;
 import j2html.tags.Tag;
 import play.mvc.Http.HttpVerbs;
 import play.mvc.Http.Request;
@@ -30,9 +31,7 @@ public final class ApplicantProgramBlockEditView extends BaseHtmlView {
 
   public Content render(Request request, long applicantId, long programId, Block block) {
     String formAction =
-        controllers.routes.ApplicantProgramBlocksController.update(
-                applicantId, programId, block.getId())
-            .url();
+        routes.ApplicantProgramBlocksController.update(applicantId, programId, block.getId()).url();
 
     return layout.render(
         h1(block.getName()),

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -37,8 +37,8 @@ GET     /demo/new                   controllers.J2HtmlDemoController.newOne(requ
 POST    /demo                       controllers.J2HtmlDemoController.create(request: Request)
 
 # Methods for applicants
-GET /applicants/:applicantId/programs                   controllers.applicant.ApplicantProgramsController.index(applicantId: Long)
-GET /applicants/:applicantId/programs/:programId/edit   controllers.applicant.ApplicantProgramsController.edit(applicantId: Long, programId: Long)
+GET     /applicants/:applicantId/programs                   controllers.applicant.ApplicantProgramsController.index(applicantId: Long)
+GET     /applicants/:applicantId/programs/:programId/edit   controllers.applicant.ApplicantProgramsController.edit(applicantId: Long, programId: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(file)

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -44,8 +44,8 @@ GET /applicants/:applicantId/programs/:programId/edit   controllers.applicant.Ap
 GET     /assets/*file               controllers.Assets.versioned(file)
 
 # Applicant program forms
-GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit   controllers.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: Long)
-POST    /applicants/:applicantId/programs/:programId/blocks/:blockId        controllers.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: Long)
+GET     /applicants/:applicantId/programs/:programId/blocks/:blockId/edit   controllers.applicant.ApplicantProgramBlocksController.edit(request: Request, applicantId: Long, programId: Long, blockId: Long)
+POST    /applicants/:applicantId/programs/:programId/blocks/:blockId        controllers.applicant.ApplicantProgramBlocksController.update(request: Request, applicantId: Long, programId: Long, blockId: Long)
 
 # User profile pages
 GET     /users/me                    controllers.ProfileController.myProfile(request: Request)

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramBlocksControllerTest.java
@@ -6,8 +6,6 @@ import static play.mvc.Http.Status.NOT_FOUND;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.fakeRequest;
 
-import controllers.ApplicantProgramBlocksController;
-import controllers.routes;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
`ApplicantProgramBlocksController` was added to the `controllers` package after a PR moved `ApplicantProgramsController` to a new `controllers.applicant` package. This PR puts them in the same package.
