### PR TITLE
These logs are super noisy, shut them all off.

### DIFF
--- a/universal-application-tool-0.0.1/conf/logback.xml
+++ b/universal-application-tool-0.0.1/conf/logback.xml
@@ -29,7 +29,7 @@
   <logger name="loggingfilter" level="INFO" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+  <logger name="com.gargoylesoftware.htmlunit" level="OFF" />
 
   <root level="WARN">
     <appender-ref ref="ASYNCFILE" />


### PR DESCRIPTION
### Description
Turn off the logs for all the javascript and css failures in unit tests.  They're not helpful and they clutter output.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
