### PR TITLE
Use latest trilom version.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-18.04 # for older version of awscli.
     steps:
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
       - name: fail if created from a fork
         if: contains(toJSON(steps.file_changes.outputs.files), 'infra/') && github.event.pull_request.head.repo.full_name != github.repository
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04 # for older version of awscli.
     steps:
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Use latest trilom version 1.2.4. This should fix a problem we're having with cloudformation.

See: https://github.com/trilom/file-changes-action/issues/93 and https://github.com/trilom/file-changes-action/pull/99

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary