### PR TITLE
Pull Authorizers out of Roles into its own class, and add authorizers…

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/Authorizers.java
+++ b/universal-application-tool-0.0.1/app/auth/Authorizers.java
@@ -1,0 +1,36 @@
+package auth;
+
+/**
+ * This enum represents Authorizers to be used with pac4j.
+ *
+ * <p>The enum values should always look like &#60;Authorizer&#62;(Labels.&#60;Authorizer&#62;).
+ */
+public enum Authorizers {
+  APPLICANT(Labels.APPLICANT),
+  UAT_ADMIN(Labels.UAT_ADMIN),
+  TI(Labels.TI),
+  PROGRAM_ADMIN(Labels.PROGRAM_ADMIN);
+
+  /**
+   * This Labels class is used to provide constant variables for annotations. This nested static
+   * class should only contain constant string values that are used to initialize {@link
+   * Authorizers}.
+   */
+  public static final class Labels {
+    public static final String APPLICANT = "applicant";
+    public static final String UAT_ADMIN = "uatadmin";
+    public static final String TI = "trustedintermediary";
+    public static final String PROGRAM_ADMIN = "programadmin";
+  }
+
+  private final String label;
+
+  private Authorizers(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public String toString() {
+    return this.label;
+  }
+}

--- a/universal-application-tool-0.0.1/app/auth/Authorizers.java
+++ b/universal-application-tool-0.0.1/app/auth/Authorizers.java
@@ -3,7 +3,7 @@ package auth;
 /**
  * This enum represents Authorizers to be used with pac4j.
  *
- * <p>The enum values should always look like &#60;Authorizer&#62;(Labels.&#60;Authorizer&#62;).
+ * <p>The enum values should always look like &lt;Authorizer&gt;(Labels.&lt;Authorizer&gt;).
  */
 public enum Authorizers {
   APPLICANT(Labels.APPLICANT),

--- a/universal-application-tool-0.0.1/app/auth/Authorizers.java
+++ b/universal-application-tool-0.0.1/app/auth/Authorizers.java
@@ -12,9 +12,9 @@ public enum Authorizers {
   PROGRAM_ADMIN(Labels.PROGRAM_ADMIN);
 
   /**
-   * This Labels class is used to provide constant variables for annotations. This nested static
-   * class should only contain constant string values that are used to initialize {@link
-   * Authorizers}.
+   * This Labels class is required to provide references to String constants for {@link
+   * org.pac4j.play.java.Secure} annotations. This nested static class should only contain constant
+   * string values that are used to initialize {@link Authorizers}.
    */
   public static final class Labels {
     public static final String APPLICANT = "applicant";

--- a/universal-application-tool-0.0.1/app/auth/Roles.java
+++ b/universal-application-tool-0.0.1/app/auth/Roles.java
@@ -7,10 +7,6 @@ public enum Roles {
   ROLE_PROGRAM_ADMIN("ROLE_PROGRAM_ADMIN");
 
   private final String roleName;
-  public static final String APPLICANT_AUTHORIZER = "applicant";
-  public static final String UAT_ADMIN_AUTHORIZER = "uatadmin";
-  public static final String TI_AUTHORIZER = "trustedintermediary";
-  public static final String PROGRAM_ADMIN_AUTHORIZER = "programadmin";
 
   Roles(String roleName) {
     this.roleName = roleName;

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -2,9 +2,11 @@ package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.Authorizers;
 import forms.BlockForm;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
 import play.data.Form;
 import play.data.FormFactory;
 import play.mvc.Controller;
@@ -38,6 +40,7 @@ public class AdminProgramBlocksController extends Controller {
     this.formFactory = checkNotNull(formFactory);
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result index(long programId) {
     Optional<ProgramDefinition> programMaybe = programService.getProgramDefinition(programId);
 
@@ -56,6 +59,7 @@ public class AdminProgramBlocksController extends Controller {
             programId, program.blockDefinitions().get(program.blockDefinitions().size() - 1).id()));
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result create(long programId) {
     ProgramDefinition program;
 
@@ -71,6 +75,7 @@ public class AdminProgramBlocksController extends Controller {
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId).url());
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result edit(Request request, long programId, long blockId) {
     Optional<ProgramDefinition> programMaybe = programService.getProgramDefinition(programId);
 
@@ -92,6 +97,7 @@ public class AdminProgramBlocksController extends Controller {
     return ok(editView.render(request, program, block, roQuestionService.getAllQuestions()));
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result update(Request request, long programId, long blockId) {
     Form<BlockForm> blockFormWrapper = formFactory.form(BlockForm.class);
     BlockForm blockForm = blockFormWrapper.bindFromRequest(request).get();
@@ -105,6 +111,7 @@ public class AdminProgramBlocksController extends Controller {
     return redirect(routes.AdminProgramBlocksController.edit(programId, blockId));
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result destroy(long programId, long blockId) {
     try {
       programService.deleteBlock(programId, blockId);

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramController.java
@@ -2,7 +2,7 @@ package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import auth.Roles;
+import auth.Authorizers;
 import forms.ProgramForm;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -42,17 +42,17 @@ public class AdminProgramController extends Controller {
     this.formFactory = checkNotNull(formFactory);
   }
 
-  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result index() {
     return ok(listView.render(this.service.listProgramDefinitions()));
   }
 
-  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result newOne(Request request) {
     return ok(newOneView.render(request));
   }
 
-  @Secure(authorizers = Roles.UAT_ADMIN_AUTHORIZER)
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result create(Request request) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();
@@ -60,6 +60,7 @@ public class AdminProgramController extends Controller {
     return redirect(routes.AdminProgramController.index().url());
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result edit(Request request, long id) {
     Optional<ProgramDefinition> program = service.getProgramDefinition(id);
     if (program.isEmpty()) {
@@ -69,6 +70,7 @@ public class AdminProgramController extends Controller {
     }
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result update(Request request, long id) {
     Form<ProgramForm> programForm = formFactory.form(ProgramForm.class);
     ProgramForm program = programForm.bindFromRequest(request).get();

--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -2,10 +2,12 @@ package controllers.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import auth.Authorizers;
 import forms.QuestionForm;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.data.Form;
@@ -44,6 +46,7 @@ public class QuestionController extends Controller {
     this.httpExecutionContext = checkNotNull(httpExecutionContext);
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public CompletionStage<Result> create(Request request) {
     Form<QuestionForm> form = formFactory.form(QuestionForm.class);
     QuestionForm questionForm = form.bindFromRequest(request).get();
@@ -63,6 +66,7 @@ public class QuestionController extends Controller {
             httpExecutionContext.current());
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public CompletionStage<Result> edit(Request request, String path) {
     return service
         .getReadOnlyQuestionService()
@@ -79,10 +83,12 @@ public class QuestionController extends Controller {
             httpExecutionContext.current());
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public Result newOne(Request request) {
     return ok(editView.renderNewQuestionForm(request));
   }
 
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public CompletionStage<Result> index(String renderAs) {
     return service
         .getReadOnlyQuestionService()
@@ -102,6 +108,7 @@ public class QuestionController extends Controller {
 
   // TODO: Implement update question.
   // https://github.com/seattle-uat/universal-application-tool/issues/103
+  @Secure(authorizers = Authorizers.Labels.UAT_ADMIN)
   public CompletionStage<Result> update(Request request, Long id) {
     Form<QuestionForm> form = formFactory.form(QuestionForm.class);
     QuestionForm questionForm = form.bindFromRequest(request).get();

--- a/universal-application-tool-0.0.1/app/modules/SecurityModule.java
+++ b/universal-application-tool-0.0.1/app/modules/SecurityModule.java
@@ -1,9 +1,15 @@
 package modules;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static play.mvc.Results.*;
+import static play.mvc.Results.forbidden;
+import static play.mvc.Results.redirect;
 
-import auth.*;
+import auth.Authorizers;
+import auth.FakeAdminClient;
+import auth.GuestClient;
+import auth.ProfileFactory;
+import auth.Roles;
+import auth.UatProfileData;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
@@ -122,14 +128,16 @@ public class SecurityModule extends AbstractModule {
     Config config = new Config();
     config.setClients(clients);
     config.addAuthorizer(
-        Roles.PROGRAM_ADMIN_AUTHORIZER,
+        Authorizers.PROGRAM_ADMIN.toString(),
         new RequireAllRolesAuthorizer(Roles.ROLE_PROGRAM_ADMIN.toString()));
     config.addAuthorizer(
-        Roles.UAT_ADMIN_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
+        Authorizers.UAT_ADMIN.toString(),
+        new RequireAllRolesAuthorizer(Roles.ROLE_UAT_ADMIN.toString()));
     config.addAuthorizer(
-        Roles.APPLICANT_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
+        Authorizers.APPLICANT.toString(),
+        new RequireAllRolesAuthorizer(Roles.ROLE_APPLICANT.toString()));
     config.addAuthorizer(
-        Roles.TI_AUTHORIZER, new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
+        Authorizers.TI.toString(), new RequireAllRolesAuthorizer(Roles.ROLE_TI.toString()));
 
     config.setHttpActionAdapter(PlayHttpActionAdapter.INSTANCE);
     return config;


### PR DESCRIPTION
… to admin controller methods.

### Description
Authorizers cannot _just_ be an enum because annotations require values to be constants and a `toString()` method on the enum class doesn't work. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
