### PR TITLE
Controllers and views for adding/removing questions to blocks

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -11,6 +11,7 @@ import play.data.FormFactory;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import services.program.DuplicateProgramQuestionException;
 import services.program.ProgramBlockNotFoundException;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
@@ -44,7 +45,11 @@ public class AdminProgramBlockQuestionsController extends Controller {
     } catch (ProgramBlockNotFoundException e) {
       return notFound(String.format("Block ID %d not found for Program %d", blockId, programId));
     } catch (QuestionNotFoundException e) {
-      return notFound(String.format("Question ID %s not found", questionIds));
+      return notFound(String.format("Question IDs %s not found", questionIds));
+    } catch (DuplicateProgramQuestionException e) {
+      return notFound(
+          String.format(
+              "Some Question IDs %s already exist in Program ID %d", questionIds, programId));
     }
 
     return redirect(controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId));

--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlockQuestionsController.java
@@ -1,0 +1,48 @@
+package controllers.admin;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import auth.Authorizers.Labels;
+import com.google.common.collect.ImmutableList;
+import javax.inject.Inject;
+import org.pac4j.play.java.Secure;
+import play.data.DynamicForm;
+import play.data.FormFactory;
+import play.mvc.Controller;
+import play.mvc.Http.Request;
+import play.mvc.Result;
+import services.program.ProgramService;
+
+public class AdminProgramBlockQuestionsController extends Controller {
+
+  private final ProgramService programService;
+  private final FormFactory formFactory;
+
+  @Inject
+  public AdminProgramBlockQuestionsController(ProgramService programService,
+      FormFactory formFactory) {
+    this.programService = checkNotNull(programService);
+    this.formFactory = checkNotNull(formFactory);
+  }
+
+  @Secure(authorizers = Labels.UAT_ADMIN)
+  public Result create(Request request, long programId, long blockId) {
+    DynamicForm requestData = formFactory.form().bindFromRequest(request);
+
+    ImmutableList<Long> questionIds = requestData.rawData().entrySet().stream()
+        .filter(formField -> formField.getKey().startsWith("question-"))
+        .map(formField -> Long.getLong(formField.getValue()))
+        .collect(ImmutableList.toImmutableList());
+
+    programService.addQuestionsToBlock(programId, blockId, questionIds);
+
+    return redirect(controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId));
+  }
+
+  @Secure(authorizers = Labels.UAT_ADMIN)
+  public Result destroy(Request request, long programId, long blockId, long questionId) {
+    DynamicForm requestData = formFactory.form().bindFromRequest(request);
+    System.out.println(requestData.rawData());
+    return redirect(controllers.admin.routes.AdminProgramBlocksController.edit(programId, blockId));
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/DuplicateProgramQuestionException.java
+++ b/universal-application-tool-0.0.1/app/services/program/DuplicateProgramQuestionException.java
@@ -1,0 +1,8 @@
+package services.program;
+
+public class DuplicateProgramQuestionException extends Exception {
+  public DuplicateProgramQuestionException(long programId, long questionId) {
+    super(
+        String.format("Question (ID %d) already exists in Program (ID %d)", questionId, programId));
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/ProgramBlockNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramBlockNotFoundException.java
@@ -1,7 +1,7 @@
 package services.program;
 
 public class ProgramBlockNotFoundException extends Exception {
-  public ProgramBlockNotFoundException(long programid, long blockid) {
-    super("Block not found in Program (ID " + programid + ") for block ID " + blockid);
+  public ProgramBlockNotFoundException(long programId, long blockId) {
+    super("Block not found in Program (ID " + programId + ") for block ID " + blockId);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -3,37 +3,56 @@ package services.program;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import java.util.Optional;
-
 import com.google.common.collect.ImmutableSet;
+import java.util.Optional;
 import models.Program;
 import services.question.QuestionDefinition;
 
 @AutoValue
 public abstract class ProgramDefinition {
 
-  /** Unique identifier for a ProgramDefinition. */
+  private Optional<ImmutableSet<Long>> questionIds = Optional.empty();
+
+  public static Builder builder() {
+    return new AutoValue_ProgramDefinition.Builder();
+  }
+
+  /**
+   * Unique identifier for a ProgramDefinition.
+   */
   public abstract long id();
 
-  /** Descriptive name of a Program, e.g. Car Tab Rebate Program */
+  /**
+   * Descriptive name of a Program, e.g. Car Tab Rebate Program
+   */
   public abstract String name();
 
-  /** A human readable description of a Program. */
+  /**
+   * A human readable description of a Program.
+   */
   public abstract String description();
 
-  /** The list of {@link BlockDefinition}s that make up the program. */
+  /**
+   * The list of {@link BlockDefinition}s that make up the program.
+   */
   public abstract ImmutableList<BlockDefinition> blockDefinitions();
 
-  /** The list of {@link ExportDefinition}s that make up the program. */
+  /**
+   * The list of {@link ExportDefinition}s that make up the program.
+   */
   public abstract ImmutableList<ExportDefinition> exportDefinitions();
 
-  /** Returns the {@link QuestionDefinition} at the specified block and question indices. */
+  /**
+   * Returns the {@link QuestionDefinition} at the specified block and question indices.
+   */
   @JsonIgnore
   public QuestionDefinition getQuestionDefinition(int blockIndex, int questionIndex) {
     return blockDefinitions().get(blockIndex).getQuestionDefinition(questionIndex);
   }
 
-  /** Returns the {@link BlockDefinition} at the specified block index if available. */
+  /**
+   * Returns the {@link BlockDefinition} at the specified block index if available.
+   */
   public Optional<BlockDefinition> getBlockDefinition(int blockIndex) {
     if (blockIndex < 0 || blockIndex >= blockDefinitions().size()) {
       return Optional.empty();
@@ -41,7 +60,9 @@ public abstract class ProgramDefinition {
     return Optional.of(blockDefinitions().get(blockIndex));
   }
 
-  /** Returns the {@link BlockDefinition} with the specified block id if available. */
+  /**
+   * Returns the {@link BlockDefinition} with the specified block id if available.
+   */
   public Optional<BlockDefinition> getBlockDefinition(long blockId) {
     return blockDefinitions().stream().filter(b -> b.id() == blockId).findAny();
   }
@@ -57,7 +78,15 @@ public abstract class ProgramDefinition {
   private ImmutableSet<Long> questionIds;
 
   public boolean hasQuestion(QuestionDefinition question) {
+    if (questionIds.isEmpty()) {
+      questionIds = Optional
+          .of(blockDefinitions().stream().map(BlockDefinition::programQuestionDefinitions)
+              .flatMap(ImmutableList::stream)
+              .map(ProgramQuestionDefinition::getQuestionDefinition).map(QuestionDefinition::getId)
+              .collect(ImmutableSet.toImmutableSet()));
+    }
 
+    return questionIds.get().contains(question.getId());
   }
 
   public Program toProgram() {
@@ -66,12 +95,9 @@ public abstract class ProgramDefinition {
 
   public abstract Builder toBuilder();
 
-  public static Builder builder() {
-    return new AutoValue_ProgramDefinition.Builder();
-  }
-
   @AutoValue.Builder
   public abstract static class Builder {
+
     public abstract Builder setId(long id);
 
     public abstract Builder setName(String name);

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -60,8 +60,6 @@ public abstract class ProgramDefinition {
   public int getQuestionCount() {
     return blockDefinitions().stream().mapToInt(BlockDefinition::getQuestionCount).sum();
 
-  private ImmutableSet<Long> questionIds;
-
   /** True if a question with the given question's ID is in the program. */
   @JsonIgnore
   public boolean hasQuestion(QuestionDefinition question) {

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -56,17 +56,20 @@ public abstract class ProgramDefinition {
     return blockDefinitions().size();
   }
 
+  @JsonIgnore
   public int getQuestionCount() {
     return blockDefinitions().stream().mapToInt(BlockDefinition::getQuestionCount).sum();
 
   private ImmutableSet<Long> questionIds;
 
   /** True if a question with the given question's ID is in the program. */
+  @JsonIgnore
   public boolean hasQuestion(QuestionDefinition question) {
     return hasQuestion(question.getId());
   }
 
   /** True if a question with the given questionId is in the program. */
+  @JsonIgnore
   public boolean hasQuestion(long questionId) {
     if (questionIds.isEmpty()) {
       questionIds =

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -59,6 +59,7 @@ public abstract class ProgramDefinition {
   @JsonIgnore
   public int getQuestionCount() {
     return blockDefinitions().stream().mapToInt(BlockDefinition::getQuestionCount).sum();
+  }
 
   /** True if a question with the given question's ID is in the program. */
   @JsonIgnore

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -17,42 +17,28 @@ public abstract class ProgramDefinition {
     return new AutoValue_ProgramDefinition.Builder();
   }
 
-  /**
-   * Unique identifier for a ProgramDefinition.
-   */
+  /** Unique identifier for a ProgramDefinition. */
   public abstract long id();
 
-  /**
-   * Descriptive name of a Program, e.g. Car Tab Rebate Program
-   */
+  /** Descriptive name of a Program, e.g. Car Tab Rebate Program */
   public abstract String name();
 
-  /**
-   * A human readable description of a Program.
-   */
+  /** A human readable description of a Program. */
   public abstract String description();
 
-  /**
-   * The list of {@link BlockDefinition}s that make up the program.
-   */
+  /** The list of {@link BlockDefinition}s that make up the program. */
   public abstract ImmutableList<BlockDefinition> blockDefinitions();
 
-  /**
-   * The list of {@link ExportDefinition}s that make up the program.
-   */
+  /** The list of {@link ExportDefinition}s that make up the program. */
   public abstract ImmutableList<ExportDefinition> exportDefinitions();
 
-  /**
-   * Returns the {@link QuestionDefinition} at the specified block and question indices.
-   */
+  /** Returns the {@link QuestionDefinition} at the specified block and question indices. */
   @JsonIgnore
   public QuestionDefinition getQuestionDefinition(int blockIndex, int questionIndex) {
     return blockDefinitions().get(blockIndex).getQuestionDefinition(questionIndex);
   }
 
-  /**
-   * Returns the {@link BlockDefinition} at the specified block index if available.
-   */
+  /** Returns the {@link BlockDefinition} at the specified block index if available. */
   public Optional<BlockDefinition> getBlockDefinition(int blockIndex) {
     if (blockIndex < 0 || blockIndex >= blockDefinitions().size()) {
       return Optional.empty();
@@ -60,9 +46,7 @@ public abstract class ProgramDefinition {
     return Optional.of(blockDefinitions().get(blockIndex));
   }
 
-  /**
-   * Returns the {@link BlockDefinition} with the specified block id if available.
-   */
+  /** Returns the {@link BlockDefinition} with the specified block id if available. */
   public Optional<BlockDefinition> getBlockDefinition(long blockId) {
     return blockDefinitions().stream().filter(b -> b.id() == blockId).findAny();
   }
@@ -77,16 +61,25 @@ public abstract class ProgramDefinition {
 
   private ImmutableSet<Long> questionIds;
 
+  /** True if a question with the given question's ID is in the program. */
   public boolean hasQuestion(QuestionDefinition question) {
+    return hasQuestion(question.getId());
+  }
+
+  /** True if a question with the given questionId is in the program. */
+  public boolean hasQuestion(long questionId) {
     if (questionIds.isEmpty()) {
-      questionIds = Optional
-          .of(blockDefinitions().stream().map(BlockDefinition::programQuestionDefinitions)
-              .flatMap(ImmutableList::stream)
-              .map(ProgramQuestionDefinition::getQuestionDefinition).map(QuestionDefinition::getId)
-              .collect(ImmutableSet.toImmutableSet()));
+      questionIds =
+          Optional.of(
+              blockDefinitions().stream()
+                  .map(BlockDefinition::programQuestionDefinitions)
+                  .flatMap(ImmutableList::stream)
+                  .map(ProgramQuestionDefinition::getQuestionDefinition)
+                  .map(QuestionDefinition::getId)
+                  .collect(ImmutableSet.toImmutableSet()));
     }
 
-    return questionIds.get().contains(question.getId());
+    return questionIds.get().contains(questionId);
   }
 
   public Program toProgram() {

--- a/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramDefinition.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
+
+import com.google.common.collect.ImmutableSet;
 import models.Program;
 import services.question.QuestionDefinition;
 
@@ -51,6 +53,11 @@ public abstract class ProgramDefinition {
 
   public int getQuestionCount() {
     return blockDefinitions().stream().mapToInt(BlockDefinition::getQuestionCount).sum();
+
+  private ImmutableSet<Long> questionIds;
+
+  public boolean hasQuestion(QuestionDefinition question) {
+
   }
 
   public Program toProgram() {

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -137,9 +137,7 @@ public interface ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ProgramDefinition addQuestionsToBlock(
-      long programId,
-      long blockDefinitionId,
-      ImmutableList<Long> questionIds)
+      long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
       throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException;
 
   /**

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -128,7 +128,7 @@ public interface ProgramService {
       throws ProgramNotFoundException, ProgramBlockNotFoundException;
 
   /**
-   * Update a {@link BlockDefinition} with a set of questions.
+   * Update a {@link BlockDefinition} to include additional questions.
    *
    * @param programId the ID of the program to update
    * @param blockDefinitionId the ID of the block to update
@@ -137,6 +137,19 @@ public interface ProgramService {
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ProgramDefinition addQuestionsToBlock(
+      long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
+      throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException;
+
+  /**
+   * Update a {@link BlockDefinition} to remove questions.
+   *
+   * @param programId the ID of the program to update
+   * @param blockDefinitionId the ID of the block to update
+   * @param questionIds an {@link ImmutableList} of question IDs to be removed from the block
+   * @return the updated {@link ProgramDefinition}
+   * @throws ProgramNotFoundException when programId does not correspond to a real Program.
+   */
+  ProgramDefinition removeQuestionsFromBlock(
       long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
       throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException;
 

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import forms.BlockForm;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import services.question.QuestionNotFoundException;
 
 /** Operations you can perform on {@link ProgramDefinition}s. */
 public interface ProgramService {
@@ -71,6 +72,7 @@ public interface ProgramService {
    */
   ProgramDefinition addBlockToProgram(long programId, String blockName, String blockDescription)
       throws ProgramNotFoundException;
+
   /**
    * Adds an empty {@link BlockDefinition} to the given program.
    *
@@ -124,6 +126,21 @@ public interface ProgramService {
       long blockDefinitionId,
       ImmutableList<ProgramQuestionDefinition> programQuestionDefinitions)
       throws ProgramNotFoundException, ProgramBlockNotFoundException;
+
+  /**
+   * Update a {@link BlockDefinition} with a set of questions.
+   *
+   * @param programId the ID of the program to update
+   * @param blockDefinitionId the ID of the block to update
+   * @param questionIds an {@link ImmutableList} of question IDs for the block
+   * @return the updated {@link ProgramDefinition}
+   * @throws ProgramNotFoundException when programId does not correspond to a real Program.
+   */
+  ProgramDefinition addQuestionsToBlock(
+      long programId,
+      long blockDefinitionId,
+      ImmutableList<Long> questionIds)
+      throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException;
 
   /**
    * Set the hide {@link Predicate} for a block. This predicate describes under what conditions the

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -138,7 +138,8 @@ public interface ProgramService {
    */
   ProgramDefinition addQuestionsToBlock(
       long programId, long blockDefinitionId, ImmutableList<Long> questionIds)
-      throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException;
+      throws ProgramNotFoundException, ProgramBlockNotFoundException, QuestionNotFoundException,
+          DuplicateProgramQuestionException;
 
   /**
    * Update a {@link BlockDefinition} to remove questions.

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -201,15 +201,12 @@ public class ProgramServiceImpl implements ProgramService {
     ImmutableList.Builder<ProgramQuestionDefinition> newQuestionListBuilder =
         ImmutableList.builder();
     newQuestionListBuilder.addAll(programQuestionDefinitions);
-    questionIds.forEach(
-        qid -> {
-          try {
-            newQuestionListBuilder.add(
-                ProgramQuestionDefinition.create(roQuestionService.getQuestionDefinition(qid)));
-          } catch (QuestionNotFoundException e) {
-            // do nothing
-          }
-        });
+
+    for (long qid : questionIds) {
+      newQuestionListBuilder.add(
+          ProgramQuestionDefinition.create(roQuestionService.getQuestionDefinition(qid)));
+    }
+
     ImmutableList<ProgramQuestionDefinition> newProgramQuestionDefinitions =
         newQuestionListBuilder.build();
 

--- a/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
@@ -8,6 +8,6 @@ public class QuestionNotFoundException extends Exception {
   public QuestionNotFoundException(long questionId, long programId) {
     super(
         String.format(
-            "Question not found for Question (ID %d) in Program (ID %d)", questionId, programId));
+            "Question (ID %d) not found in Program (ID %d)", questionId, programId));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
@@ -1,13 +1,11 @@
 package services.question;
 
 public class QuestionNotFoundException extends Exception {
-  public QuestionNotFoundException(long id) {
-    super("Question not found for ID: " + id);
+  public QuestionNotFoundException(long questionId) {
+    super(String.format("Question not found for ID: %d", questionId));
   }
 
   public QuestionNotFoundException(long questionId, long programId) {
-    super(
-        String.format(
-            "Question (ID %d) not found in Program (ID %d)", questionId, programId));
+    super(String.format("Question (ID %d) not found in Program (ID %d)", questionId, programId));
   }
 }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionNotFoundException.java
@@ -4,4 +4,10 @@ public class QuestionNotFoundException extends Exception {
   public QuestionNotFoundException(long id) {
     super("Question not found for ID: " + id);
   }
+
+  public QuestionNotFoundException(long questionId, long programId) {
+    super(
+        String.format(
+            "Question not found for Question (ID %d) in Program (ID %d)", questionId, programId));
+  }
 }

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -65,6 +65,13 @@ public abstract class BaseHtmlView {
     return textAreaWithLabel(labelValue, inputId, optionalValue);
   }
 
+  protected Tag checkboxInputWithLabel(String labelText, String inputId, String inputName,
+      String inputValue) {
+    return label()
+        .with(
+            input().withType("checkbox").withName(inputName).withValue(inputValue).withId(inputId), text(labelText));
+  }
+
   protected Tag textField(String fieldName, String labelText) {
     return label()
         .with(text(labelText), input().withType("text").withName(fieldName))
@@ -78,7 +85,7 @@ public abstract class BaseHtmlView {
 
   protected Tag textFieldWithValue(String fieldName, String labelText, String placeholder) {
     return label(
-            text(labelText), input().withType("text").withName(fieldName).withValue(placeholder))
+        text(labelText), input().withType("text").withName(fieldName).withValue(placeholder))
         .attr(Attr.FOR, fieldName);
   }
 

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -65,11 +65,12 @@ public abstract class BaseHtmlView {
     return textAreaWithLabel(labelValue, inputId, optionalValue);
   }
 
-  protected Tag checkboxInputWithLabel(String labelText, String inputId, String inputName,
-      String inputValue) {
+  protected Tag checkboxInputWithLabel(
+      String labelText, String inputId, String inputName, String inputValue) {
     return label()
         .with(
-            input().withType("checkbox").withName(inputName).withValue(inputValue).withId(inputId), text(labelText));
+            input().withType("checkbox").withName(inputName).withValue(inputValue).withId(inputId),
+            text(labelText));
   }
 
   protected Tag textField(String fieldName, String labelText) {
@@ -85,7 +86,7 @@ public abstract class BaseHtmlView {
 
   protected Tag textFieldWithValue(String fieldName, String labelText, String placeholder) {
     return label(
-        text(labelText), input().withType("text").withName(fieldName).withValue(placeholder))
+            text(labelText), input().withType("text").withName(fieldName).withValue(placeholder))
         .attr(Attr.FOR, fieldName);
   }
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -84,7 +84,15 @@ public class ProgramBlockEditView extends BaseHtmlView {
 
     block
         .programQuestionDefinitions()
-        .forEach(pqd -> questionList.with(li(pqd.getQuestionDefinition().getName())));
+        .forEach(
+            pqd ->
+                questionList.with(
+                    li(
+                        checkboxInputWithLabel(
+                            pqd.getQuestionDefinition().getName(),
+                            "block-question-" + pqd.getQuestionDefinition().getId(),
+                            "block-question-" + pqd.getQuestionDefinition().getId(),
+                            String.valueOf(pqd.getQuestionDefinition().getId())))));
 
     return div()
         .withClass(Styles.FLEX_AUTO)
@@ -103,7 +111,15 @@ public class ProgramBlockEditView extends BaseHtmlView {
                         controllers.admin.routes.AdminProgramBlocksController.update(
                                 program.id(), block.id())
                             .url()),
-                questionList));
+                form()
+                    .withMethod("post")
+                    .withAction(
+                        controllers.admin.routes.AdminProgramBlockQuestionsController.destroy(
+                                program.id(), block.id())
+                            .url())
+                    .with(csrfTag)
+                    .with(questionList)
+                    .with(submitButton("Remove questions"))));
   }
 
   private ContainerTag blockEditPanelTop(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -80,23 +80,30 @@ public class ProgramBlockEditView extends BaseHtmlView {
 
   private ContainerTag blockEditPanel(
       Tag csrfTag, ProgramDefinition program, BlockDefinition block) {
+    ContainerTag questionList = ul();
+
+    block
+        .programQuestionDefinitions()
+        .forEach(pqd -> questionList.with(li(pqd.getQuestionDefinition().getName())));
+
     return div()
         .withClass(Styles.FLEX_AUTO)
         .with(blockEditPanelTop(csrfTag, program, block))
         .with(
             div(
                 form(
-                    csrfTag,
-                    div(textFieldWithValue("name", "Block Name", block.name())),
-                    div(
-                        textFieldWithValue(
-                            "description", "Block Description", block.description())),
-                    submitButton("Update Block"))
+                        csrfTag,
+                        div(textFieldWithValue("name", "Block Name", block.name())),
+                        div(
+                            textFieldWithValue(
+                                "description", "Block Description", block.description())),
+                        submitButton("Update Block"))
                     .withMethod("post")
                     .withAction(
                         controllers.admin.routes.AdminProgramBlocksController.update(
-                            program.id(), block.id())
-                            .url())));
+                                program.id(), block.id())
+                            .url()),
+                questionList));
   }
 
   private ContainerTag blockEditPanelTop(
@@ -109,24 +116,33 @@ public class ProgramBlockEditView extends BaseHtmlView {
     return div().withClass(Styles.FLEX).with(h1(block.name())).with(deleteButton);
   }
 
-  private ContainerTag questionBankPanel(Tag csrfTag,
-      ImmutableList<QuestionDefinition> questionDefinitions, ProgramDefinition program,
+  private ContainerTag questionBankPanel(
+      Tag csrfTag,
+      ImmutableList<QuestionDefinition> questionDefinitions,
+      ProgramDefinition program,
       BlockDefinition block) {
     ContainerTag questionBank = div().withClasses(Styles.FLEX_INITIAL).with(h2("Question Bank"));
-    ContainerTag form = form().withMethod("post").withAction(
-        controllers.admin.routes.AdminProgramBlockQuestionsController
-            .create(program.id(), block.id()).url())
-        .with(csrfTag)
-        .with(submitButton("Add to Block"));
+    ContainerTag form =
+        form()
+            .withMethod("post")
+            .withAction(
+                controllers.admin.routes.AdminProgramBlockQuestionsController.create(
+                        program.id(), block.id())
+                    .url())
+            .with(csrfTag)
+            .with(submitButton("Add to Block"));
 
     ContainerTag questionList = ul().withClass(Styles.OVERFLOW_X_SCROLL);
 
     questionDefinitions.forEach(
-        questionDefinition -> questionList.with(li(
-            checkboxInputWithLabel(questionDefinition.getName(), "" + questionDefinition.getId(),
-                "question-" + questionDefinition.getId(),
-                String.valueOf(questionDefinition.getId()))
-        )));
+        questionDefinition ->
+            questionList.with(
+                li(
+                    checkboxInputWithLabel(
+                        questionDefinition.getName(),
+                        "" + questionDefinition.getId(),
+                        "question-" + questionDefinition.getId(),
+                        String.valueOf(questionDefinition.getId())))));
 
     return questionBank.with(form.with(questionList));
   }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -45,7 +45,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .withClasses(Styles.FLEX)
             .with(blockOrderPanel(program, block))
             .with(blockEditPanel(csrfTag, program, block))
-            .with(questionBankPanel(questions)));
+            .with(questionBankPanel(csrfTag, questions, program, block)));
   }
 
   private Tag title(ProgramDefinition program) {
@@ -86,16 +86,16 @@ public class ProgramBlockEditView extends BaseHtmlView {
         .with(
             div(
                 form(
-                        csrfTag,
-                        div(textFieldWithValue("name", "Block Name", block.name())),
-                        div(
-                            textFieldWithValue(
-                                "description", "Block Description", block.description())),
-                        submitButton("Update Block"))
+                    csrfTag,
+                    div(textFieldWithValue("name", "Block Name", block.name())),
+                    div(
+                        textFieldWithValue(
+                            "description", "Block Description", block.description())),
+                    submitButton("Update Block"))
                     .withMethod("post")
                     .withAction(
                         controllers.admin.routes.AdminProgramBlocksController.update(
-                                program.id(), block.id())
+                            program.id(), block.id())
                             .url())));
   }
 
@@ -109,12 +109,25 @@ public class ProgramBlockEditView extends BaseHtmlView {
     return div().withClass(Styles.FLEX).with(h1(block.name())).with(deleteButton);
   }
 
-  private ContainerTag questionBankPanel(ImmutableList<QuestionDefinition> questionDefinitions) {
+  private ContainerTag questionBankPanel(Tag csrfTag,
+      ImmutableList<QuestionDefinition> questionDefinitions, ProgramDefinition program,
+      BlockDefinition block) {
+    ContainerTag questionBank = div().withClasses(Styles.FLEX_INITIAL).with(h2("Question Bank"));
+    ContainerTag form = form().withMethod("post").withAction(
+        controllers.admin.routes.AdminProgramBlockQuestionsController
+            .create(program.id(), block.id()).url())
+        .with(csrfTag)
+        .with(submitButton("Add to Block"));
+
     ContainerTag questionList = ul().withClass(Styles.OVERFLOW_X_SCROLL);
 
     questionDefinitions.forEach(
-        questionDefinition -> questionList.with(li(questionDefinition.getName())));
+        questionDefinition -> questionList.with(li(
+            checkboxInputWithLabel(questionDefinition.getName(), "" + questionDefinition.getId(),
+                "question-" + questionDefinition.getId(),
+                String.valueOf(questionDefinition.getId()))
+        )));
 
-    return div().withClasses(Styles.FLEX_INITIAL).with(h2("Question Bank")).with(questionList);
+    return questionBank.with(form.with(questionList));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -92,16 +92,16 @@ public class ProgramBlockEditView extends BaseHtmlView {
         .with(
             div(
                 form(
-                    csrfTag,
-                    div(textFieldWithValue("name", "Block Name", block.name())),
-                    div(
-                        textFieldWithValue(
-                            "description", "Block Description", block.description())),
-                    submitButton("Update Block"))
+                        csrfTag,
+                        div(textFieldWithValue("name", "Block Name", block.name())),
+                        div(
+                            textFieldWithValue(
+                                "description", "Block Description", block.description())),
+                        submitButton("Update Block"))
                     .withMethod("post")
                     .withAction(
                         controllers.admin.routes.AdminProgramBlocksController.update(
-                            program.id(), block.id())
+                                program.id(), block.id())
                             .url()),
                 questionList));
   }
@@ -127,23 +127,24 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .withMethod("post")
             .withAction(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.create(
-                    program.id(), block.id())
+                        program.id(), block.id())
                     .url())
             .with(csrfTag)
             .with(submitButton("Add to Block"));
 
-
     ContainerTag questionList = ul().withClass(Styles.OVERFLOW_X_SCROLL);
 
-    questionDefinitions.stream().filter(question -> !program.hasQuestion(question)).forEach(
-        questionDefinition ->
-            questionList.with(
-                li(
-                    checkboxInputWithLabel(
-                        questionDefinition.getName(),
-                        "" + questionDefinition.getId(),
-                        "question-" + questionDefinition.getId(),
-                        String.valueOf(questionDefinition.getId())))));
+    questionDefinitions.stream()
+        .filter(question -> !program.hasQuestion(question))
+        .forEach(
+            questionDefinition ->
+                questionList.with(
+                    li(
+                        checkboxInputWithLabel(
+                            questionDefinition.getName(),
+                            "" + questionDefinition.getId(),
+                            "question-" + questionDefinition.getId(),
+                            String.valueOf(questionDefinition.getId())))));
 
     return questionBank.with(form.with(questionList));
   }

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -92,16 +92,16 @@ public class ProgramBlockEditView extends BaseHtmlView {
         .with(
             div(
                 form(
-                        csrfTag,
-                        div(textFieldWithValue("name", "Block Name", block.name())),
-                        div(
-                            textFieldWithValue(
-                                "description", "Block Description", block.description())),
-                        submitButton("Update Block"))
+                    csrfTag,
+                    div(textFieldWithValue("name", "Block Name", block.name())),
+                    div(
+                        textFieldWithValue(
+                            "description", "Block Description", block.description())),
+                    submitButton("Update Block"))
                     .withMethod("post")
                     .withAction(
                         controllers.admin.routes.AdminProgramBlocksController.update(
-                                program.id(), block.id())
+                            program.id(), block.id())
                             .url()),
                 questionList));
   }
@@ -127,14 +127,15 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .withMethod("post")
             .withAction(
                 controllers.admin.routes.AdminProgramBlockQuestionsController.create(
-                        program.id(), block.id())
+                    program.id(), block.id())
                     .url())
             .with(csrfTag)
             .with(submitButton("Add to Block"));
 
+
     ContainerTag questionList = ul().withClass(Styles.OVERFLOW_X_SCROLL);
 
-    questionDefinitions.forEach(
+    questionDefinitions.stream().filter(question -> !program.hasQuestion(question)).forEach(
         questionDefinition ->
             questionList.with(
                 li(

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -158,7 +158,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
                     li(
                         checkboxInputWithLabel(
                             questionDefinition.getName(),
-                            "" + questionDefinition.getId(),
+                            "question-" + questionDefinition.getId(),
                             "question-" + questionDefinition.getId(),
                             String.valueOf(questionDefinition.getId())))));
 

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -80,8 +80,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
 
   private ContainerTag blockEditPanel(
       Tag csrfTag, ProgramDefinition program, BlockDefinition block) {
-    ContainerTag questionList = ul();
-
+    ContainerTag questionList = ul().withId("blockQuestions");
     block
         .programQuestionDefinitions()
         .forEach(
@@ -148,7 +147,8 @@ public class ProgramBlockEditView extends BaseHtmlView {
             .with(csrfTag)
             .with(submitButton("Add to Block"));
 
-    ContainerTag questionList = ul().withClass(Styles.OVERFLOW_X_SCROLL);
+    ContainerTag questionList =
+        ul().withId("questionBankQuestions").withClass(Styles.OVERFLOW_X_SCROLL);
 
     questionDefinitions.stream()
         .filter(question -> !program.hasQuestion(question))

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -21,6 +21,10 @@ POST    /admin/programs/:programId/blocks/:blockId           controllers.admin.A
 GET     /admin/programs/:programId/blocks/create             controllers.admin.AdminProgramBlocksController.create(programId: Long)
 POST    /admin/programs/:programId/blocks/:blockId/delete    controllers.admin.AdminProgramBlocksController.destroy(programId: Long, blockId: Long)
 
+# A controller for adding and removing questions from program blocks
+POST    /admin/programs/:programId/blocks/:blockId/questions               controllers.admin.AdminProgramBlockQuestionsController.create(request: Request, programId: Long, blockId: Long)
+POST    /admin/programs/:programId/blocks/:blockId/questions/:questionId   controllers.admin.AdminProgramBlockQuestionsController.destroy(request: Request, programId: Long, blockId: Long, questionId: Long)
+
 # A controller for a page for an admin to view, edit, and create questions
 GET     /admin/questions             controllers.admin.QuestionController.index(request: Request, renderAs: String ?= "table")
 GET     /admin/questions/new         controllers.admin.QuestionController.newOne(request: Request)

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -23,7 +23,7 @@ POST    /admin/programs/:programId/blocks/:blockId/delete    controllers.admin.A
 
 # A controller for adding and removing questions from program blocks
 POST    /admin/programs/:programId/blocks/:blockId/questions               controllers.admin.AdminProgramBlockQuestionsController.create(request: Request, programId: Long, blockId: Long)
-POST    /admin/programs/:programId/blocks/:blockId/questions/:questionId   controllers.admin.AdminProgramBlockQuestionsController.destroy(request: Request, programId: Long, blockId: Long, questionId: Long)
+POST    /admin/programs/:programId/blocks/:blockId/questions/delete        controllers.admin.AdminProgramBlockQuestionsController.destroy(request: Request, programId: Long, blockId: Long)
 
 # A controller for a page for an admin to view, edit, and create questions
 GET     /admin/questions             controllers.admin.QuestionController.index(request: Request, renderAs: String ?= "table")

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -73,13 +73,12 @@ public class BaseBrowserTest extends WithBrowser {
   }
 
   /**
-   * Add a program through the admin flow. This will log the user in as an admin and log them out
-   * after the program is added.
+   * Add a program through the admin flow. This requires that an admin is logged in.
    *
    * @param name a name for the new program
    */
   protected void addProgram(String name) {
-    // Go to admin index and click "New Program"
+    // Go to admin program index and click "New Program".
     goTo(controllers.admin.routes.AdminProgramController.index());
     browser.$("#new-program").click();
 
@@ -87,6 +86,26 @@ public class BaseBrowserTest extends WithBrowser {
     browser.$("input", withName("name")).fill().with(name);
     browser.$("input", withName("description")).fill().with("Test description");
     browser.$("button", withText("Create")).click();
+
+    // Check that program is added.
+    assertThat(browser.pageSource()).contains(name);
+  }
+
+  /** Add a question through the admin flow. This requires the admin is logged in. */
+  protected void addQuestion(String questionName) {
+    // Go to admin question index and click "Create a new question".
+    goTo(controllers.admin.routes.QuestionController.index("table"));
+    browser.$("a", withText("Create a new question")).first().click();
+
+    // Fill out the question form and click submit.
+    browser.$("input", withName("questionName")).fill().with(questionName);
+    browser.$("input", withName("questionDescription")).fill().with("question description");
+    browser.$("input", withName("questionPath")).fill().with(questionName.replace(" ", "."));
+    browser.$("textarea", withName("questionText")).fill().with("question text");
+    browser.$("button", withText("Create")).first().click();
+
+    // Check that question is added.
+    assertThat(browser.pageSource()).contains(questionName);
   }
 
   /**
@@ -96,9 +115,42 @@ public class BaseBrowserTest extends WithBrowser {
    */
   protected void manageExistingProgramQuestions(String programName) {
     goTo(controllers.admin.routes.AdminProgramController.index());
-    browser.$("div", containingText(programName)).$("a").first().click();
+    browser.$("div", containingText(programName)).$("a", withText("edit")).first().click();
     assertThat(browser.pageSource()).contains("Edit program: " + programName);
     browser.$("a", withText("Manage Questions")).first().click();
     assertThat(browser.pageSource()).contains(programName + " Questions");
+  }
+
+  protected void addQuestionsToProgram(String programName, String... questions) {
+    manageExistingProgramQuestions(programName);
+
+    // Add questions to the block.
+    for (String question : questions) {
+      browser.$("#questionBankQuestions").$("label", withText(question)).$("input").first().click();
+    }
+    browser.$("button", containingText("Add to Block")).first().click();
+
+    // Check that questions are added.
+    for (String question : questions) {
+      assertThat(browser.$("#blockQuestions").$("li").textContents()).contains(question);
+      assertThat(browser.$("#questionBankQuestions").$("li").textContents())
+          .doesNotContain(question);
+    }
+  }
+
+  protected void removeQuestionsToProgram(String programName, String... questions) {
+    manageExistingProgramQuestions(programName);
+
+    // Remove questions to the block.
+    for (String question : questions) {
+      browser.$("#blockQuestions").$("label", withText(question)).$("input").first().click();
+    }
+    browser.$("button", containingText("Remove questions")).first().click();
+
+    // Check that questions are removed.
+    for (String question : questions) {
+      assertThat(browser.$("#blockQuestions").$("li").textContents()).doesNotContain(question);
+      assertThat(browser.$("#questionBankQuestions").$("li").textContents()).contains(question);
+    }
   }
 }

--- a/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/BaseBrowserTest.java
@@ -115,7 +115,7 @@ public class BaseBrowserTest extends WithBrowser {
    */
   protected void manageExistingProgramQuestions(String programName) {
     goTo(controllers.admin.routes.AdminProgramController.index());
-    browser.$("div", containingText(programName)).$("a", withText("edit")).first().click();
+    browser.$("div", containingText(programName)).$("a", containingText("Edit")).first().click();
     assertThat(browser.pageSource()).contains("Edit program: " + programName);
     browser.$("a", withText("Manage Questions")).first().click();
     assertThat(browser.pageSource()).contains(programName + " Questions");

--- a/universal-application-tool-0.0.1/test/app/ProgramAdministrationBrowserTest.java
+++ b/universal-application-tool-0.0.1/test/app/ProgramAdministrationBrowserTest.java
@@ -24,4 +24,34 @@ public class ProgramAdministrationBrowserTest extends BaseBrowserTest {
     assertThat(browser.$("input", withName("description")).values())
         .contains("updated block description");
   }
+
+  @Test
+  public void addAndRemoveQuestionsToAProgram() {
+    String questionName = "name question";
+    String questionRemovedName = "removed question";
+    String programName = "Reduced fee lunches";
+
+    loginAsAdmin();
+    addQuestion(questionName);
+    addQuestion(questionRemovedName);
+    addProgram(programName);
+    addQuestionsToProgram(programName, questionName, questionRemovedName);
+
+    assertThat(browser.$("#blockQuestions").$("li").textContents()).contains(questionName);
+    assertThat(browser.$("#blockQuestions").$("li").textContents()).contains(questionRemovedName);
+    assertThat(browser.$("#questionBlockQuestions").$("li").textContents())
+        .doesNotContain(questionName);
+    assertThat(browser.$("#questionBlockQuestions").$("li").textContents())
+        .doesNotContain(questionRemovedName);
+
+    removeQuestionsToProgram(programName, questionRemovedName);
+
+    assertThat(browser.$("#blockQuestions").$("li").textContents()).contains(questionName);
+    assertThat(browser.$("#blockQuestions").$("li").textContents())
+        .doesNotContain(questionRemovedName);
+    assertThat(browser.$("#questionBlockQuestions").$("li").textContents())
+        .doesNotContain(questionName);
+    assertThat(browser.$("#questionBankQuestions").$("li").textContents())
+        .contains(questionRemovedName);
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -2,9 +2,15 @@ package services.program;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import org.junit.Test;
+import services.question.QuestionDefinition;
+import services.question.QuestionDefinitionBuilder;
+import services.question.QuestionType;
 
 public class ProgramDefinitionTest {
+
   @Test
   public void createProgramDefinition() {
     BlockDefinition blockA =
@@ -50,5 +56,68 @@ public class ProgramDefinitionTest {
             .build();
 
     assertThat(program.getBlockDefinition(0)).isEmpty();
+  }
+
+  @Test
+  public void hasQuestion_trueIfTheProgramUsesTheQuestion() throws Exception {
+    QuestionDefinition questionA =
+        new QuestionDefinitionBuilder()
+            .setId(1L)
+            .setVersion(1L)
+            .setName("my name")
+            .setPath("my.path.name")
+            .setDescription("description")
+            .setQuestionType(QuestionType.TEXT)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+    QuestionDefinition questionB =
+        new QuestionDefinitionBuilder()
+            .setId(2L)
+            .setVersion(1L)
+            .setName("my name")
+            .setPath("my.path.name")
+            .setDescription("description")
+            .setQuestionType(QuestionType.TEXT)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+    QuestionDefinition questionC =
+        new QuestionDefinitionBuilder()
+            .setId(3L)
+            .setVersion(1L)
+            .setName("my name")
+            .setPath("my.path.name")
+            .setDescription("description")
+            .setQuestionType(QuestionType.TEXT)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+
+    BlockDefinition blockA =
+        BlockDefinition.builder()
+            .setId(123L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .addQuestion(ProgramQuestionDefinition.create(questionA))
+            .build();
+
+    BlockDefinition blockB =
+        BlockDefinition.builder()
+            .setId(321L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .addQuestion(ProgramQuestionDefinition.create(questionB))
+            .build();
+
+    ProgramDefinition program =
+        ProgramDefinition.builder()
+            .setId(123L)
+            .setName("The Program")
+            .setDescription("This program is for testing.")
+            .addBlockDefinition(blockA)
+            .addBlockDefinition(blockB)
+            .build();
+
+    assertThat(program.hasQuestion(questionA)).isTrue();
+    assertThat(program.hasQuestion(questionB)).isTrue();
+    assertThat(program.hasQuestion(questionC)).isFalse();
   }
 }

--- a/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramDefinitionTest.java
@@ -69,7 +69,8 @@ public class ProgramDefinitionTest {
             .setDescription("description")
             .setQuestionType(QuestionType.TEXT)
             .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
-            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text"))
+            .build();
     QuestionDefinition questionB =
         new QuestionDefinitionBuilder()
             .setId(2L)
@@ -79,7 +80,8 @@ public class ProgramDefinitionTest {
             .setDescription("description")
             .setQuestionType(QuestionType.TEXT)
             .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
-            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text"))
+            .build();
     QuestionDefinition questionC =
         new QuestionDefinitionBuilder()
             .setId(3L)
@@ -89,7 +91,8 @@ public class ProgramDefinitionTest {
             .setDescription("description")
             .setQuestionType(QuestionType.TEXT)
             .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "question?"))
-            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text")).build();
+            .setQuestionHelpText(ImmutableMap.of(Locale.ENGLISH, "help text"))
+            .build();
 
     BlockDefinition blockA =
         BlockDefinition.builder()

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -512,7 +512,9 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     program.id(), block.id(), ImmutableList.of(questionA.getId())))
         .isInstanceOf(DuplicateProgramQuestionException.class)
         .hasMessage(
-            String.format("Question (ID %d) already exists in Program (ID 1)", questionA.getId()));
+            String.format(
+                "Question (ID %d) already exists in Program (ID %d)",
+                questionA.getId(), program.id()));
     ;
   }
 
@@ -562,7 +564,8 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     program.id(), block.id(), ImmutableList.of(questionA.getId())))
         .isInstanceOf(QuestionNotFoundException.class)
         .hasMessage(
-            String.format("Question (ID %d) not found in Program (ID 1)", questionA.getId()));
+            String.format(
+                "Question (ID %d) not found in Program (ID %d)", questionA.getId(), program.id()));
     ;
   }
 


### PR DESCRIPTION
### Description
Adds `ProgramService` methods `addQuestionsToBlock` and `removeQuestionsFromBlock.

Adds `DuplicateProgramQuestionException` to be thrown when `addQuestionsToBlock` attempts to add a question that is already in the program.

Adds `AdminProgramBlockQuestionsController` for POST methods to add and remove questions to a block.

Adds forms to `ProgramBlockEditView` to add and remove questions to a block. 

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #110 
[Fixes] #111 
[Fixes] #83 
[Fixes] #88 
[Fixes] #139 