### PR TITLE
Convert a form-fill PDF to a "config" PDF.

### DIFF
--- a/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
+++ b/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
@@ -22,6 +22,16 @@ import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
 import org.apache.pdfbox.pdmodel.interactive.form.*;
 
 public class PdfMapAssistant {
+    /**
+     * Creates and returns a new document, which is a copy of the provided document,
+     * except that every form field is converted to a list-selector, in which you can
+     * select one of the list of provided questions.
+     * This maintains the names of the fields, so the resulting PDF, once filled in, is
+     * suitable for reading as a configuration method for PDF export.
+     * The method for submitting this configuration PDF is to-be-determined since, as noted
+     * in https://bugs.chromium.org/p/chromium/issues/detail?id=719344, Chrome
+     * does not support PDF submit-buttons.
+     */
     public static PDDocument convertToMapPdf(PDDocument doc, ImmutableList<Question> questions) throws IOException {
         // Create a copy of the document by writing it to an in-memory object and re-loading it.
         ByteArrayOutputStream inMemoryDoc = new ByteArrayOutputStream();
@@ -30,19 +40,27 @@ public class PdfMapAssistant {
         PDDocument newDoc = PDDocument.load(inMemoryDoc.toByteArray());
         // discard in-memory object now that it's loaded.
         inMemoryDoc.reset();
+
+        // Create the list of strings in the internal PDF format.
+        COSArray optionsArray = new COSArray();
+        for (Question question : questions) {
+            optionsArray.add(new COSString(question.getQuestionDefinition().getName()));
+        }
+
         for (PDField field : newDoc.getDocumentCatalog().getAcroForm().getFields()) {
             COSDictionary fieldDict = field.getCOSObject();
-            COSArray arr = new COSArray();
-            for (Question opt : questions) {
-                arr.add(new COSString(opt.getQuestionDefinition().getName()));
-            }
             // Set the list of options (PDF /Opt).
-            fieldDict.setItem(COSName.OPT, arr);
+            fieldDict.setItem(COSName.OPT, optionsArray);
             // Set the field type to list box (PDF /Ch).
             fieldDict.setItem(COSName.FT, COSName.CH);
             // Set the field to required (field flag [/Ff] mask 0x2).
             fieldDict.setFlag(COSName.FF, 0x2, true);
         }
+
+        // Note that you cannot have a submit button at the end of the PDF.
+        // The PDF spec supports it, but Chrome, which is the most popular browser,
+        // does not.  It would work in Acrobat, but we can't realistically tell people
+        // what PDF reader to use.
         return newDoc;
     }
 }

--- a/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
+++ b/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
@@ -1,7 +1,6 @@
 package export;
 
 import com.google.common.collect.ImmutableList;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import models.Question;
@@ -10,57 +9,51 @@ import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSString;
 import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDPage;
-import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.common.filespecification.PDSimpleFileSpecification;
-import org.apache.pdfbox.pdmodel.interactive.action.PDActionJavaScript;
-import org.apache.pdfbox.pdmodel.interactive.action.PDActionSubmitForm;
-import org.apache.pdfbox.pdmodel.interactive.action.PDAnnotationAdditionalActions;
-import org.apache.pdfbox.pdmodel.interactive.action.PDFormFieldAdditionalActions;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
-import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
 import org.apache.pdfbox.pdmodel.interactive.form.*;
 
 public class PdfMapAssistant {
-    /**
-     * Creates and returns a new document, which is a copy of the provided document,
-     * except that every form field is converted to a list-selector, in which you can
-     * select one of the list of provided questions.
-     * This maintains the names of the fields, so the resulting PDF, once filled in, is
-     * suitable for reading as a configuration method for PDF export.
-     * The method for submitting this configuration PDF is to-be-determined since, as noted
-     * in https://bugs.chromium.org/p/chromium/issues/detail?id=719344, Chrome
-     * does not support PDF submit-buttons.
-     */
-    public static PDDocument convertToMapPdf(PDDocument doc, ImmutableList<Question> questions) throws IOException {
-        // Create a copy of the document by writing it to an in-memory object and re-loading it.
-        ByteArrayOutputStream inMemoryDoc = new ByteArrayOutputStream();
-        doc.save(inMemoryDoc);
-        inMemoryDoc.close();
-        PDDocument newDoc = PDDocument.load(inMemoryDoc.toByteArray());
-        // discard in-memory object now that it's loaded.
-        inMemoryDoc.reset();
+  // the bit to set for requiredness in a PDF form.
+  private static int REQUIRED = 0x2;
 
-        // Create the list of strings in the internal PDF format.
-        COSArray optionsArray = new COSArray();
-        for (Question question : questions) {
-            optionsArray.add(new COSString(question.getQuestionDefinition().getName()));
-        }
+  /**
+   * Creates and returns a new document, which is a copy of the provided document, except that every
+   * form field is converted to a list-selector, in which you can select one of the list of provided
+   * questions. This maintains the names of the fields, so the resulting PDF, once filled in, is
+   * suitable for reading as a configuration method for PDF export. The method for submitting this
+   * configuration PDF is to-be-determined since, as noted in
+   * https://bugs.chromium.org/p/chromium/issues/detail?id=719344, Chrome does not support PDF
+   * submit-buttons.
+   */
+  public static PDDocument convertToMapPdf(PDDocument doc, ImmutableList<Question> questions)
+      throws IOException {
+    // Create a copy of the document by writing it to an in-memory object and re-loading it.
+    ByteArrayOutputStream inMemoryDoc = new ByteArrayOutputStream();
+    doc.save(inMemoryDoc);
+    inMemoryDoc.close();
+    PDDocument newDoc = PDDocument.load(inMemoryDoc.toByteArray());
+    // discard in-memory object now that it's loaded.
+    inMemoryDoc.reset();
 
-        for (PDField field : newDoc.getDocumentCatalog().getAcroForm().getFields()) {
-            COSDictionary fieldDict = field.getCOSObject();
-            // Set the list of options (PDF /Opt).
-            fieldDict.setItem(COSName.OPT, optionsArray);
-            // Set the field type to list box (PDF /Ch).
-            fieldDict.setItem(COSName.FT, COSName.CH);
-            // Set the field to required (field flag [/Ff] mask 0x2).
-            fieldDict.setFlag(COSName.FF, 0x2, true);
-        }
-
-        // Note that you cannot have a submit button at the end of the PDF.
-        // The PDF spec supports it, but Chrome, which is the most popular browser,
-        // does not.  It would work in Acrobat, but we can't realistically tell people
-        // what PDF reader to use.
-        return newDoc;
+    // Create the list of strings in the internal PDF format.
+    COSArray optionsArray = new COSArray();
+    for (Question question : questions) {
+      optionsArray.add(new COSString(question.getQuestionDefinition().getName()));
     }
+
+    for (PDField field : newDoc.getDocumentCatalog().getAcroForm().getFields()) {
+      COSDictionary fieldDict = field.getCOSObject();
+      // Set the list of options (PDF /Opt).
+      fieldDict.setItem(COSName.OPT, optionsArray);
+      // Set the field type to list box (PDF /Ch).
+      fieldDict.setItem(COSName.FT, COSName.CH);
+      // Set the field to required (field flag [/Ff] mask 0x2).
+      fieldDict.setFlag(COSName.FF, REQUIRED, true);
+    }
+
+    // Note that you cannot have a submit button at the end of the PDF.
+    // The PDF spec supports it, but Chrome, which is the most popular browser,
+    // does not.  It would work in Acrobat, but we can't realistically tell people
+    // what PDF reader to use.
+    return newDoc;
+  }
 }

--- a/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
+++ b/universal-application-tool-0.0.1/app/export/PdfMapAssistant.java
@@ -1,0 +1,48 @@
+package export;
+
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import models.Question;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSString;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDSimpleFileSpecification;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionJavaScript;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionSubmitForm;
+import org.apache.pdfbox.pdmodel.interactive.action.PDAnnotationAdditionalActions;
+import org.apache.pdfbox.pdmodel.interactive.action.PDFormFieldAdditionalActions;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationWidget;
+import org.apache.pdfbox.pdmodel.interactive.form.*;
+
+public class PdfMapAssistant {
+    public static PDDocument convertToMapPdf(PDDocument doc, ImmutableList<Question> questions) throws IOException {
+        // Create a copy of the document by writing it to an in-memory object and re-loading it.
+        ByteArrayOutputStream inMemoryDoc = new ByteArrayOutputStream();
+        doc.save(inMemoryDoc);
+        inMemoryDoc.close();
+        PDDocument newDoc = PDDocument.load(inMemoryDoc.toByteArray());
+        // discard in-memory object now that it's loaded.
+        inMemoryDoc.reset();
+        for (PDField field : newDoc.getDocumentCatalog().getAcroForm().getFields()) {
+            COSDictionary fieldDict = field.getCOSObject();
+            COSArray arr = new COSArray();
+            for (Question opt : questions) {
+                arr.add(new COSString(opt.getQuestionDefinition().getName()));
+            }
+            // Set the list of options (PDF /Opt).
+            fieldDict.setItem(COSName.OPT, arr);
+            // Set the field type to list box (PDF /Ch).
+            fieldDict.setItem(COSName.FT, COSName.CH);
+            // Set the field to required (field flag [/Ff] mask 0x2).
+            fieldDict.setFlag(COSName.FF, 0x2, true);
+        }
+        return newDoc;
+    }
+}

--- a/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
@@ -45,8 +45,8 @@ public class PdfMapAssistantTest {
         PDField newField = newDoc.getDocumentCatalog().getAcroForm().getField("formfield");
         assertThat(newField).isNotNull();
         assertThat(newField).isInstanceOf(PDListBox.class);
-        assertThat(newField.isRequired()).isTrue();
         assertThat(((PDListBox)newField).getOptions()).hasSameElementsAs(ImmutableList.of("foo", "bar"));
+        assertThat(newField.isRequired()).isTrue();
         newDoc.close();
     }
 }

--- a/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
@@ -1,0 +1,52 @@
+package export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import models.Question;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSObject;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.form.PDField;
+import org.apache.pdfbox.pdmodel.interactive.form.PDListBox;
+import org.junit.Test;
+import services.question.QuestionDefinition;
+import services.question.QuestionDefinitionBuilder;
+import services.question.QuestionType;
+import services.question.UnsupportedQuestionTypeException;
+
+public class PdfMapAssistantTest {
+    public Question makeFakeQuestionWithName(String name) throws UnsupportedQuestionTypeException {
+        QuestionDefinition questionDefinition = new QuestionDefinitionBuilder().setName(name).
+                setDescription("fake question").setQuestionText(ImmutableMap.of()).setQuestionHelpText(ImmutableMap.of())
+                .setQuestionType(QuestionType.TEXT).setPath("$.applicant.fake.path").
+                build();
+        return new Question(questionDefinition);
+    }
+
+    @Test
+    public void testMapping() throws IOException, UnsupportedQuestionTypeException {
+        // Check that the form is as expected.
+        File basePdf = new File("test/export/base.pdf");
+        assertThat(basePdf.canRead()).isTrue();
+        PDDocument doc = PDDocument.load(basePdf);
+        PDField formfield = doc.getDocumentCatalog().getAcroForm().getField("formfield");
+        assertThat(formfield).isNotNull();
+        assertThat(formfield.getValueAsString()).isEmpty();
+
+        PDDocument newDoc = PdfMapAssistant.convertToMapPdf(doc, ImmutableList.of(
+                makeFakeQuestionWithName("foo"), makeFakeQuestionWithName("bar")
+        ));
+        doc.close();
+
+        PDField newField = newDoc.getDocumentCatalog().getAcroForm().getField("formfield");
+        assertThat(newField).isNotNull();
+        assertThat(newField).isInstanceOf(PDListBox.class);
+        assertThat(newField.isRequired()).isTrue();
+        assertThat(((PDListBox)newField).getOptions()).hasSameElementsAs(ImmutableList.of("foo", "bar"));
+        newDoc.close();
+    }
+}

--- a/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
+++ b/universal-application-tool-0.0.1/test/export/PdfMapAssistantTest.java
@@ -7,8 +7,6 @@ import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import models.Question;
-import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.form.PDField;
 import org.apache.pdfbox.pdmodel.interactive.form.PDListBox;
@@ -19,34 +17,41 @@ import services.question.QuestionType;
 import services.question.UnsupportedQuestionTypeException;
 
 public class PdfMapAssistantTest {
-    public Question makeFakeQuestionWithName(String name) throws UnsupportedQuestionTypeException {
-        QuestionDefinition questionDefinition = new QuestionDefinitionBuilder().setName(name).
-                setDescription("fake question").setQuestionText(ImmutableMap.of()).setQuestionHelpText(ImmutableMap.of())
-                .setQuestionType(QuestionType.TEXT).setPath("$.applicant.fake.path").
-                build();
-        return new Question(questionDefinition);
-    }
+  public Question makeFakeQuestionWithName(String name) throws UnsupportedQuestionTypeException {
+    QuestionDefinition questionDefinition =
+        new QuestionDefinitionBuilder()
+            .setName(name)
+            .setDescription("fake question")
+            .setQuestionText(ImmutableMap.of())
+            .setQuestionHelpText(ImmutableMap.of())
+            .setQuestionType(QuestionType.TEXT)
+            .setPath("$.applicant.fake.path")
+            .build();
+    return new Question(questionDefinition);
+  }
 
-    @Test
-    public void testMapping() throws IOException, UnsupportedQuestionTypeException {
-        // Check that the form is as expected.
-        File basePdf = new File("test/export/base.pdf");
-        assertThat(basePdf.canRead()).isTrue();
-        PDDocument doc = PDDocument.load(basePdf);
-        PDField formfield = doc.getDocumentCatalog().getAcroForm().getField("formfield");
-        assertThat(formfield).isNotNull();
-        assertThat(formfield.getValueAsString()).isEmpty();
+  @Test
+  public void testMapping() throws IOException, UnsupportedQuestionTypeException {
+    // Check that the form is as expected.
+    File basePdf = new File("test/export/base.pdf");
+    assertThat(basePdf.canRead()).isTrue();
+    PDDocument doc = PDDocument.load(basePdf);
+    PDField formfield = doc.getDocumentCatalog().getAcroForm().getField("formfield");
+    assertThat(formfield).isNotNull();
+    assertThat(formfield.getValueAsString()).isEmpty();
 
-        PDDocument newDoc = PdfMapAssistant.convertToMapPdf(doc, ImmutableList.of(
-                makeFakeQuestionWithName("foo"), makeFakeQuestionWithName("bar")
-        ));
-        doc.close();
+    PDDocument newDoc =
+        PdfMapAssistant.convertToMapPdf(
+            doc,
+            ImmutableList.of(makeFakeQuestionWithName("foo"), makeFakeQuestionWithName("bar")));
+    doc.close();
 
-        PDField newField = newDoc.getDocumentCatalog().getAcroForm().getField("formfield");
-        assertThat(newField).isNotNull();
-        assertThat(newField).isInstanceOf(PDListBox.class);
-        assertThat(((PDListBox)newField).getOptions()).hasSameElementsAs(ImmutableList.of("foo", "bar"));
-        assertThat(newField.isRequired()).isTrue();
-        newDoc.close();
-    }
+    PDField newField = newDoc.getDocumentCatalog().getAcroForm().getField("formfield");
+    assertThat(newField).isNotNull();
+    assertThat(newField).isInstanceOf(PDListBox.class);
+    assertThat(((PDListBox) newField).getOptions())
+        .hasSameElementsAs(ImmutableList.of("foo", "bar"));
+    assertThat(newField.isRequired()).isTrue();
+    newDoc.close();
+  }
 }


### PR DESCRIPTION
### Description
This produces a PDF which is nearly identical to the input PDF, except that instead of text boxes / checkboxes, all the fields are lists of questions to map.

This will be useful in ring 3, especially for #181.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
