### PR TITLE
Surface question validation failure

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -17,10 +17,12 @@ import play.libs.concurrent.HttpExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http.Request;
 import play.mvc.Result;
+import services.ErrorAnd;
 import services.question.InvalidPathException;
 import services.question.InvalidUpdateException;
 import services.question.QuestionDefinition;
 import services.question.QuestionService;
+import services.question.QuestionServiceError;
 import services.question.UnsupportedQuestionTypeException;
 import views.admin.questions.QuestionEditView;
 import views.admin.questions.QuestionsListView;
@@ -59,12 +61,12 @@ public class QuestionController extends Controller {
               String exception = "";
               try {
                 QuestionDefinition definition = questionForm.getBuilder().setVersion(1L).build();
-                boolean success = service.create(definition).hasResult();
-                if (!success) {
-                  exception =
-                      String.format(
-                          "create failed: this is most likely you specify an invalid path %s",
-                          definition.getPath());
+                ErrorAnd<QuestionDefinition, QuestionServiceError> result =
+                    service.create(definition);
+                if (result.isError()) {
+                  for (QuestionServiceError e : result.getErrors()) {
+                    exception += e.message();
+                  }
                 }
               } catch (UnsupportedQuestionTypeException e) {
                 exception = e.toString();

--- a/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/QuestionController.java
@@ -59,7 +59,7 @@ public class QuestionController extends Controller {
               String exception = "";
               try {
                 QuestionDefinition definition = questionForm.getBuilder().setVersion(1L).build();
-                boolean success = service.create(definition).isPresent();
+                boolean success = service.create(definition).hasResult();
                 if (!success) {
                   exception =
                       String.format(

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -101,7 +101,7 @@ public class DatabaseSeedController extends Controller {
                 "description",
                 ImmutableMap.of(Locale.ENGLISH, "What is your name?"),
                 ImmutableMap.of(Locale.ENGLISH, "help text")))
-        .get();
+        .getResult();
   }
 
   private QuestionDefinition insertColorQuestionDefinition() {
@@ -114,7 +114,7 @@ public class DatabaseSeedController extends Controller {
                 "description",
                 ImmutableMap.of(Locale.ENGLISH, "What is your favorite color?"),
                 ImmutableMap.of(Locale.ENGLISH, "help text")))
-        .get();
+        .getResult();
   }
 
   private QuestionDefinition insertAddressQuestionDefinition() {
@@ -127,7 +127,7 @@ public class DatabaseSeedController extends Controller {
                 "description",
                 ImmutableMap.of(Locale.ENGLISH, "What is your address?"),
                 ImmutableMap.of(Locale.ENGLISH, "help text")))
-        .get();
+        .getResult();
   }
 
   private ProgramDefinition insertProgramWithBlocks(String name) {

--- a/universal-application-tool-0.0.1/app/services/ErrorAnd.java
+++ b/universal-application-tool-0.0.1/app/services/ErrorAnd.java
@@ -10,6 +10,18 @@ import com.google.common.collect.ImmutableSet;
  * result need be provided.
  */
 public class ErrorAnd<T, E> {
+  public static <T, E> ErrorAnd<T, E> error(ImmutableSet<E> errors) {
+    return new ErrorAnd<>(errors);
+  }
+
+  public static <T, E> ErrorAnd<T, E> errorAnd(ImmutableSet<E> errors, T result) {
+    return new ErrorAnd<>(errors, result);
+  }
+
+  public static <T, E> ErrorAnd<T, E> of(T result) {
+    return new ErrorAnd<>(result);
+  }
+
   private final ImmutableSet<E> errors;
   private final T result;
 

--- a/universal-application-tool-0.0.1/app/services/question/QuestionService.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionService.java
@@ -3,6 +3,7 @@ package services.question;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import services.ErrorAnd;
 
 public interface QuestionService {
 
@@ -20,7 +21,7 @@ public interface QuestionService {
    *
    * <p>NOTE: This does not update the version.
    */
-  Optional<QuestionDefinition> create(QuestionDefinition definition);
+  ErrorAnd<QuestionDefinition, QuestionServiceError> create(QuestionDefinition definition);
 
   /**
    * Adds a new translation to an existing question definition. Returns true if the write is

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceError.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceError.java
@@ -6,6 +6,10 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class QuestionServiceError {
 
+  public static QuestionServiceError of(String message) {
+    return new AutoValue_QuestionServiceError(message);
+  }
+
   /** The failure message. */
-  abstract String message();
+  public abstract String message();
 }

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceError.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceError.java
@@ -1,0 +1,11 @@
+package services.question;
+
+import com.google.auto.value.AutoValue;
+
+/** Represents a failure for a question service operation. */
+@AutoValue
+public abstract class QuestionServiceError {
+
+  /** The failure message. */
+  abstract String message();
+}

--- a/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/question/QuestionServiceImpl.java
@@ -3,6 +3,7 @@ package services.question;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -11,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import models.Question;
 import repository.QuestionRepository;
+import services.ErrorAnd;
 
 public final class QuestionServiceImpl implements QuestionService {
 
@@ -29,12 +31,12 @@ public final class QuestionServiceImpl implements QuestionService {
   }
 
   @Override
-  public Optional<QuestionDefinition> create(QuestionDefinition definition) {
+  public ErrorAnd<QuestionDefinition, QuestionServiceError> create(QuestionDefinition definition) {
     if (!isValid(definition)) {
-      return Optional.empty();
+      return ErrorAnd.error(ImmutableSet.of());
     }
     Question question = questionRepository.insertQuestionSync(new Question(definition));
-    return Optional.of(question.getQuestionDefinition());
+    return ErrorAnd.of(question.getQuestionDefinition());
   }
 
   @Override

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -29,7 +29,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void create_addsQuestionDefinition() throws UnsupportedQuestionTypeException {
+  public void create_redirectsOnSuccess() throws UnsupportedQuestionTypeException {
     buildQuestionsList();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
@@ -44,13 +44,16 @@ public class QuestionControllerTest extends WithPostgresContainer {
         .create(requestBuilder.build())
         .thenAccept(
             result -> {
-              assertThat(contentAsString(result)).contains("Total Questions: 2");
-              assertThat(contentAsString(result)).contains("All Questions");
-            });
+              assertThat(result.redirectLocation())
+                  .hasValue(routes.QuestionController.index("table").url());
+              assertThat(result.flash()).isNull();
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
-  public void create_failsGracefully() throws UnsupportedQuestionTypeException {
+  public void create_redirectsWithFlashOnFailure() throws UnsupportedQuestionTypeException {
     buildQuestionsList();
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionPath", "#invalid_path!");
@@ -59,10 +62,12 @@ public class QuestionControllerTest extends WithPostgresContainer {
         .create(requestBuilder.build())
         .thenAccept(
             result -> {
-              assertThat(contentAsString(result)).contains("Total Questions: 1");
-              assertThat(contentAsString(result)).contains("All Questions");
-              assertThat(contentAsString(result)).contains("create failed");
-            });
+              assertThat(result.redirectLocation())
+                  .hasValue(routes.QuestionController.index("table").url());
+              assertThat(result.flash().get("exception").get()).contains("#invalid_path!");
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -74,11 +79,11 @@ public class QuestionControllerTest extends WithPostgresContainer {
         .edit(request, "invalid.path")
         .thenAccept(
             result -> {
-              assertThat(result.status()).isEqualTo(OK);
-              assertThat(contentAsString(result)).contains("New Question");
-              assertThat(contentAsString(result))
-                  .contains(CSRF.getToken(request.asScala()).value());
-            });
+              assertThat(result.redirectLocation())
+                  .hasValue(routes.QuestionController.newOne().url());
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -91,7 +96,11 @@ public class QuestionControllerTest extends WithPostgresContainer {
             result -> {
               assertThat(result.status()).isEqualTo(OK);
               assertThat(contentAsString(result)).contains("Edit Question");
-            });
+              assertThat(contentAsString(result))
+                  .contains(CSRF.getToken(request.asScala()).value());
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -107,7 +116,9 @@ public class QuestionControllerTest extends WithPostgresContainer {
               assertThat(result.charset()).hasValue("utf-8");
               assertThat(contentAsString(result)).contains("Total Questions: 1");
               assertThat(contentAsString(result)).contains("All Questions");
-            });
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -122,7 +133,9 @@ public class QuestionControllerTest extends WithPostgresContainer {
               assertThat(result.charset()).hasValue("utf-8");
               assertThat(contentAsString(result)).contains("Total Questions: 0");
               assertThat(contentAsString(result)).contains("All Questions");
-            });
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -137,7 +150,9 @@ public class QuestionControllerTest extends WithPostgresContainer {
               assertThat(result.contentType()).hasValue("text/html");
               assertThat(result.charset()).hasValue("utf-8");
               assertThat(contentAsString(result)).contains("has exception");
-            });
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
@@ -151,7 +166,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void update_updatesQuestionDefinition() {
+  public void update_redirectsOnSuccess() {
     Question question = resourceCreator().insertQuestion("my.path");
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData
@@ -166,14 +181,16 @@ public class QuestionControllerTest extends WithPostgresContainer {
         .update(requestBuilder.build(), question.id)
         .thenAccept(
             result -> {
-              assertThat(contentAsString(result)).contains("Total Questions: 1");
-              assertThat(contentAsString(result)).contains("All Questions");
-              assertThat(contentAsString(result)).contains("question text updated");
-            });
+              assertThat(result.redirectLocation())
+                  .hasValue(routes.QuestionController.index("table").url());
+              assertThat(result.flash()).isNull();
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   @Test
-  public void update_failsGracefully() {
+  public void update_redirectsWithFlashOnFailure() {
     Question question = resourceCreator().insertQuestion("my.path");
     ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
     formData.put("questionPath", "invalid.path").put("questionText", "question text updated!");
@@ -182,11 +199,12 @@ public class QuestionControllerTest extends WithPostgresContainer {
         .update(requestBuilder.build(), question.id)
         .thenAccept(
             result -> {
-              assertThat(contentAsString(result)).contains("Total Questions: 1");
-              assertThat(contentAsString(result)).contains("All Questions");
-              assertThat(contentAsString(result)).contains("InvalidUpdateException");
-              assertThat(contentAsString(result)).doesNotContain("question text updated");
-            });
+              assertThat(result.redirectLocation())
+                  .hasValue(routes.QuestionController.index("table").url());
+              assertThat(result.flash().get("exception").get()).contains("invalid.path");
+            })
+        .toCompletableFuture()
+        .join();
   }
 
   private void buildQuestionsList() throws UnsupportedQuestionTypeException {

--- a/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/QuestionControllerTest.java
@@ -64,7 +64,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
             result -> {
               assertThat(result.redirectLocation())
                   .hasValue(routes.QuestionController.index("table").url());
-              assertThat(result.flash().get("exception").get()).contains("#invalid_path!");
+              assertThat(result.flash().get("message").get()).contains("#invalid_path!");
             })
         .toCompletableFuture()
         .join();
@@ -139,9 +139,8 @@ public class QuestionControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void index_showsExceptionFlash() {
-    Request request =
-        addCSRFToken(Helpers.fakeRequest().flash("exception", "has exception")).build();
+  public void index_showsMessageFlash() {
+    Request request = addCSRFToken(Helpers.fakeRequest().flash("message", "has message")).build();
     controller
         .index(request, "table")
         .thenAccept(
@@ -149,7 +148,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
               assertThat(result.status()).isEqualTo(OK);
               assertThat(result.contentType()).hasValue("text/html");
               assertThat(result.charset()).hasValue("utf-8");
-              assertThat(contentAsString(result)).contains("has exception");
+              assertThat(contentAsString(result)).contains("has message");
             })
         .toCompletableFuture()
         .join();
@@ -201,7 +200,7 @@ public class QuestionControllerTest extends WithPostgresContainer {
             result -> {
               assertThat(result.redirectLocation())
                   .hasValue(routes.QuestionController.index("table").url());
-              assertThat(result.flash().get("exception").get()).contains("invalid.path");
+              assertThat(result.flash().get("message").get()).contains("invalid.path");
             })
         .toCompletableFuture()
         .join();

--- a/universal-application-tool-0.0.1/test/services/ErrorAndTest.java
+++ b/universal-application-tool-0.0.1/test/services/ErrorAndTest.java
@@ -10,7 +10,7 @@ public class ErrorAndTest {
   @Test
   public void canBeCreatedWithResultAndErrors() {
     ErrorAnd<String, String> errorAndResult =
-        new ErrorAnd<>(ImmutableSet.of("error 1", "error 2"), "result");
+        ErrorAnd.errorAnd(ImmutableSet.of("error 1", "error 2"), "result");
 
     assertThat(errorAndResult.hasResult()).isTrue();
     assertThat(errorAndResult.getResult()).isEqualTo("result");
@@ -20,20 +20,19 @@ public class ErrorAndTest {
 
   @Test
   public void canBeCreatedWithOnlyErrors() {
-    ErrorAnd<String, String> errorAndResult = new ErrorAnd<>(ImmutableSet.of("error 1", "error 2"));
+    ErrorAnd<String, String> errorAndResult = ErrorAnd.error(ImmutableSet.of("error 1", "error 2"));
     Throwable thrown = catchThrowable(() -> errorAndResult.getResult());
 
     assertThat(thrown).isInstanceOf(RuntimeException.class);
     assertThat(thrown).hasMessage("There is no result");
     assertThat(errorAndResult.hasResult()).isFalse();
-    // TODO: expect errorAndResult.getResult() to throw
     assertThat(errorAndResult.isError()).isTrue();
     assertThat(errorAndResult.getErrors()).containsAll(ImmutableSet.of("error 1", "error 2"));
   }
 
   @Test
   public void canBeCreatedWithOnlyResult() {
-    ErrorAnd<String, String> errorAndResult = new ErrorAnd<>("result");
+    ErrorAnd<String, String> errorAndResult = ErrorAnd.of("result");
 
     assertThat(errorAndResult.hasResult()).isTrue();
     assertThat(errorAndResult.getResult()).isEqualTo("result");

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantServiceImplTest.java
@@ -66,7 +66,7 @@ public class ApplicantServiceImplTest extends WithPostgresContainer {
                     "description",
                     ImmutableMap.of(Locale.ENGLISH, "question?"),
                     ImmutableMap.of(Locale.ENGLISH, "help text")))
-            .get();
+            .getResult();
   }
 
   private void createProgram() throws Exception {

--- a/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/ProgramServiceImplTest.java
@@ -57,7 +57,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void listProgramDefinitions_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
@@ -95,7 +95,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void listProgramDefinitionsAsync_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
@@ -115,7 +115,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void syncQuestions_constructsAllQuestionDefinitions() throws Exception {
-    QuestionDefinition questionOne = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition questionOne = qs.create(SIMPLE_QUESTION).getResult();
     QuestionDefinition questionTwo =
         qs.create(
                 new AddressQuestionDefinition(
@@ -125,7 +125,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     "Applicant's address",
                     ImmutableMap.of(Locale.US, "What is your addess?"),
                     ImmutableMap.of()))
-            .get();
+            .getResult();
     QuestionDefinition questionThree =
         qs.create(
                 new TextQuestionDefinition(
@@ -135,7 +135,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
                     "Applicant's favorite color",
                     ImmutableMap.of(Locale.US, "Is orange your favorite color?"),
                     ImmutableMap.of()))
-            .get();
+            .getResult();
 
     ProgramDefinition programOne =
         ps.createProgramDefinition("Program One", "Program One Description");
@@ -212,7 +212,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void updateProgram_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
@@ -242,7 +242,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void getProgramDefinition_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
@@ -275,7 +275,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void getProgramDefinitionAsync_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
     ps.addQuestionsToBlock(program.id(), 1L, ImmutableList.of(question.getId()));
 
@@ -353,7 +353,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void addBlockToProgram_WithQuestions_returnsProgramDefinitionWithBlock() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition programDefinition = ps.createProgramDefinition("program", "description");
     long id = programDefinition.id();
     ProgramQuestionDefinition programQuestionDefinition =
@@ -384,7 +384,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void addBlockToProgram_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition program = ps.createProgramDefinition("Program Name", "Program Description");
 
     program =
@@ -441,7 +441,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void setBlockQuestions_updatesBlock() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
 
     ProgramDefinition programDefinition =
         ps.createProgramDefinition("Program With Block", "This program has a block.");
@@ -472,7 +472,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void setBlockQuestions_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition programDefinition =
         ps.createProgramDefinition("Program With Block", "This program has a block.");
     Long programId = programDefinition.id();
@@ -616,7 +616,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void setBlockHidePredicate_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition programDefinition =
         ps.createProgramDefinition("Program With Block", "This program has a block.");
     Long programId = programDefinition.id();
@@ -658,7 +658,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void setBlockOptionalPredicate_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition programDefinition =
         ps.createProgramDefinition("Program With Block", "This program has a block.");
     Long programId = programDefinition.id();
@@ -690,7 +690,7 @@ public class ProgramServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void deleteBlock_constructsQuestionDefinitions() throws Exception {
-    QuestionDefinition question = qs.create(SIMPLE_QUESTION).get();
+    QuestionDefinition question = qs.create(SIMPLE_QUESTION).getResult();
     ProgramDefinition programDefinition =
         ps.createProgramDefinition("Program With Block", "This program has a block.");
     Long programId = programDefinition.id();

--- a/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionDefinitionTest.java
@@ -195,4 +195,30 @@ public class QuestionDefinitionTest {
         new TextQuestionDefinition(1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
     assertThat(question.getScalarType("notPresent")).isEqualTo(Optional.empty());
   }
+
+  @Test
+  public void validateWellFormedQuestion_returnsNoErrors() {
+    QuestionDefinition question =
+        new TextQuestionDefinition(
+            1L,
+            "name",
+            "path",
+            "description",
+            ImmutableMap.of(Locale.ENGLISH, "question?"),
+            ImmutableMap.of());
+    assertThat(question.validate()).isEmpty();
+  }
+
+  @Test
+  public void validateBadQuestion_returnsErrors() {
+    QuestionDefinition question =
+        new TextQuestionDefinition(-1L, "", "", "", ImmutableMap.of(), ImmutableMap.of());
+    assertThat(question.validate())
+        .containsOnly(
+            QuestionServiceError.of("invalid version: -1"),
+            QuestionServiceError.of("blank name"),
+            QuestionServiceError.of("invalid path pattern: ''"),
+            QuestionServiceError.of("blank description"),
+            QuestionServiceError.of("no question text"));
+  }
 }

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -42,7 +42,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
   public void create_returnsOptionalEmptyWhenFails() {
     questionService.create(questionDefinition);
 
-    assertThat(questionService.create(questionDefinition).isPresent()).isFalse();
+    assertThat(questionService.create(questionDefinition).hasResult()).isFalse();
   }
 
   @Test
@@ -56,12 +56,12 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
             ImmutableMap.of(Locale.ENGLISH, "question?"),
             ImmutableMap.of());
 
-    assertThat(questionService.create(question).isPresent()).isFalse();
+    assertThat(questionService.create(question).hasResult()).isFalse();
   }
 
   @Test
   public void create_returnsQuestionDefinitionWhenSucceeds() {
-    assertThat(questionService.create(questionDefinition).get().getPath())
+    assertThat(questionService.create(questionDefinition).getResult().getPath())
         .isEqualTo(questionDefinition.getPath());
   }
 
@@ -91,7 +91,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
   @Test
   public void update_returnsQuestionDefinitionWhenSucceeds()
       throws InvalidUpdateException, UnsupportedQuestionTypeException {
-    QuestionDefinition question = questionService.create(questionDefinition).get();
+    QuestionDefinition question = questionService.create(questionDefinition).getResult();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(question).setName("updated name").build();
 
@@ -116,7 +116,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWhenQuestionPathChanges() throws UnsupportedQuestionTypeException {
-    QuestionDefinition question = questionService.create(questionDefinition).get();
+    QuestionDefinition question = questionService.create(questionDefinition).getResult();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(question).setPath("new.path").build();
 
@@ -127,7 +127,7 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
 
   @Test
   public void update_failsWhenQuestionTypeChanges() throws UnsupportedQuestionTypeException {
-    QuestionDefinition question = questionService.create(questionDefinition).get();
+    QuestionDefinition question = questionService.create(questionDefinition).getResult();
     QuestionDefinition toUpdate =
         new QuestionDefinitionBuilder(question).setQuestionType(QuestionType.ADDRESS).build();
 

--- a/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
+++ b/universal-application-tool-0.0.1/test/services/question/QuestionServiceImplTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletionStage;
 import org.junit.Before;
 import org.junit.Test;
 import repository.WithPostgresContainer;
+import services.ErrorAnd;
 
 public class QuestionServiceImplTest extends WithPostgresContainer {
   QuestionServiceImpl questionService;
@@ -39,10 +40,20 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
   }
 
   @Test
-  public void create_returnsOptionalEmptyWhenFails() {
+  public void create_failsWhenPathConflicts() {
     questionService.create(questionDefinition);
 
-    assertThat(questionService.create(questionDefinition).hasResult()).isFalse();
+    ErrorAnd<QuestionDefinition, QuestionServiceError> errorAndResult =
+        questionService.create(questionDefinition);
+
+    assertThat(errorAndResult.hasResult()).isFalse();
+    assertThat(errorAndResult.isError()).isTrue();
+    assertThat(errorAndResult.getErrors())
+        .containsOnly(
+            QuestionServiceError.of(
+                String.format(
+                    "path '%s' conflicts with question: %s",
+                    questionDefinition.getPath(), questionDefinition.getPath())));
   }
 
   @Test
@@ -56,13 +67,25 @@ public class QuestionServiceImplTest extends WithPostgresContainer {
             ImmutableMap.of(Locale.ENGLISH, "question?"),
             ImmutableMap.of());
 
-    assertThat(questionService.create(question).hasResult()).isFalse();
+    ErrorAnd<QuestionDefinition, QuestionServiceError> errorAndResult =
+        questionService.create(question);
+
+    assertThat(errorAndResult.hasResult()).isFalse();
+    assertThat(errorAndResult.isError()).isTrue();
+    assertThat(errorAndResult.getErrors())
+        .containsOnly(
+            QuestionServiceError.of(
+                String.format("invalid path pattern: '%s'", question.getPath())));
   }
 
   @Test
   public void create_returnsQuestionDefinitionWhenSucceeds() {
-    assertThat(questionService.create(questionDefinition).getResult().getPath())
-        .isEqualTo(questionDefinition.getPath());
+    ErrorAnd<QuestionDefinition, QuestionServiceError> errorAndResult =
+        questionService.create(questionDefinition);
+
+    assertThat(errorAndResult.isError()).isFalse();
+    assertThat(errorAndResult.hasResult()).isTrue();
+    assertThat(errorAndResult.getResult().getPath()).isEqualTo(questionDefinition.getPath());
   }
 
   @Test

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -54,7 +54,7 @@ public class ResourceCreator {
                 "",
                 ImmutableMap.of(Locale.ENGLISH, "question?"),
                 ImmutableMap.of(Locale.ENGLISH, "help text")))
-        .get();
+        .getResult();
   }
 
   public Program insertProgram(String name) {

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -49,9 +49,9 @@ public class ResourceCreator {
         .create(
             new TextQuestionDefinition(
                 1L,
-                "",
+                "question name",
                 "my.path.name",
-                "",
+                "description",
                 ImmutableMap.of(Locale.ENGLISH, "question?"),
                 ImmutableMap.of(Locale.ENGLISH, "help text")))
         .getResult();


### PR DESCRIPTION
### Description
Instead of throwing exceptions, we return an ErrorAnd object that contains either a valid result or a set of errors, or both if meaningful.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
