### PR TITLE
Program always has one block.

### DIFF
--- a/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
+++ b/universal-application-tool-0.0.1/app/controllers/admin/AdminProgramBlocksController.java
@@ -15,6 +15,7 @@ import play.mvc.Result;
 import services.program.BlockDefinition;
 import services.program.ProgramBlockNotFoundException;
 import services.program.ProgramDefinition;
+import services.program.ProgramNeedsABlockException;
 import services.program.ProgramNotFoundException;
 import services.program.ProgramService;
 import services.question.QuestionService;
@@ -49,10 +50,6 @@ public class AdminProgramBlocksController extends Controller {
     }
 
     ProgramDefinition program = programMaybe.get();
-
-    if (program.blockDefinitions().isEmpty()) {
-      return redirect(routes.AdminProgramBlocksController.create(programId));
-    }
 
     return redirect(
         routes.AdminProgramBlocksController.edit(
@@ -117,6 +114,8 @@ public class AdminProgramBlocksController extends Controller {
       programService.deleteBlock(programId, blockId);
     } catch (ProgramNotFoundException e) {
       return notFound(String.format("Program ID %d not found.", programId));
+    } catch (ProgramNeedsABlockException e) {
+      return notFound(String.format("Cannot delete the last block of a program."));
     }
     return redirect(routes.AdminProgramBlocksController.index(programId));
   }

--- a/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
+++ b/universal-application-tool-0.0.1/app/controllers/dev/DatabaseSeedController.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import forms.BlockForm;
 import io.ebean.Ebean;
 import io.ebean.EbeanServer;
 import java.util.Locale;
@@ -133,9 +134,15 @@ public class DatabaseSeedController extends Controller {
     try {
       ProgramDefinition programDefinition = programService.createProgramDefinition(name, "desc");
 
+      BlockForm firstBlockForm = new BlockForm();
+      firstBlockForm.setName("Block 1");
+      firstBlockForm.setDescription("name and favorite color");
+
       programDefinition =
-          programService.addBlockToProgram(
-              programDefinition.id(), "Block 1", "name and favorite color");
+          programService.updateBlock(
+              programDefinition.id(),
+              programDefinition.blockDefinitions().get(0).id(),
+              firstBlockForm);
       programDefinition =
           programService.setBlockQuestions(
               programDefinition.id(),
@@ -145,11 +152,10 @@ public class DatabaseSeedController extends Controller {
                   ProgramQuestionDefinition.create(insertColorQuestionDefinition())));
 
       programDefinition =
-          programService.addBlockToProgram(programDefinition.id(), "Block 2", "address");
-      programDefinition =
-          programService.setBlockQuestions(
+          programService.addBlockToProgram(
               programDefinition.id(),
-              programDefinition.blockDefinitions().get(1).id(),
+              "Block 2",
+              "address",
               ImmutableList.of(
                   ProgramQuestionDefinition.create(insertAddressQuestionDefinition())));
 

--- a/universal-application-tool-0.0.1/app/models/Program.java
+++ b/universal-application-tool-0.0.1/app/models/Program.java
@@ -39,10 +39,21 @@ public class Program extends BaseModel {
     this.blockDefinitions = definition.blockDefinitions();
   }
 
+  /**
+   * Construct a new Program object with the given program name and description, and with an empty
+   * block named Block 1.
+   */
   public Program(String name, String description) {
     this.name = name;
     this.description = description;
-    this.blockDefinitions = ImmutableList.of();
+    BlockDefinition emptyBlock =
+        BlockDefinition.builder()
+            .setId(1L)
+            .setName("Block 1")
+            .setDescription("")
+            .setProgramQuestionDefinitions(ImmutableList.of())
+            .build();
+    this.blockDefinitions = ImmutableList.of(emptyBlock);
   }
 
   /** Populates column values from {@link ProgramDefinition} */

--- a/universal-application-tool-0.0.1/app/services/program/ProgramNeedsABlockException.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramNeedsABlockException.java
@@ -1,0 +1,7 @@
+package services.program;
+
+public class ProgramNeedsABlockException extends Exception {
+  public ProgramNeedsABlockException(long programId) {
+    super(String.format("Cannot delete the last block of program (ID %d)", programId));
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -42,7 +42,7 @@ public interface ProgramService {
   CompletionStage<Optional<ProgramDefinition>> getProgramDefinitionAsync(long id);
 
   /**
-   * Create a new program.
+   * Create a new program with an empty block.
    *
    * @param name a name for this program
    * @param description the description of what the program provides
@@ -187,7 +187,8 @@ public interface ProgramService {
    *
    * @return the updated {@link ProgramDefinition}
    * @throws ProgramNotFoundException when programId does not correspond to a real Program.
+   * @throws ProgramNeedsABlockException when trying to delete the last block of a Program.
    */
   ProgramDefinition deleteBlock(long programId, long blockDefinitionId)
-      throws ProgramNotFoundException;
+      throws ProgramNotFoundException, ProgramNeedsABlockException;
 }

--- a/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramServiceImpl.java
@@ -296,13 +296,16 @@ public class ProgramServiceImpl implements ProgramService {
   @Override
   @Transactional
   public ProgramDefinition deleteBlock(long programId, long blockDefinitionId)
-      throws ProgramNotFoundException {
+      throws ProgramNotFoundException, ProgramNeedsABlockException {
     ProgramDefinition programDefinition = getProgramOrThrow(programId);
 
     ImmutableList<BlockDefinition> newBlocks =
         programDefinition.blockDefinitions().stream()
             .filter(block -> block.id() != blockDefinitionId)
             .collect(ImmutableList.toImmutableList());
+    if (newBlocks.isEmpty()) {
+      throw new ProgramNeedsABlockException(programId);
+    }
 
     Program program =
         programDefinition.toBuilder().setBlockDefinitions(newBlocks).build().toProgram();

--- a/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
+++ b/universal-application-tool-0.0.1/app/views/admin/programs/ProgramBlockEditView.java
@@ -40,7 +40,7 @@ public class ProgramBlockEditView extends BaseHtmlView {
 
     return layout.render(
         title(program),
-        topButtons(program),
+        topButtons(csrfTag, program),
         div()
             .withClasses(Styles.FLEX)
             .with(blockOrderPanel(program, block))
@@ -52,11 +52,13 @@ public class ProgramBlockEditView extends BaseHtmlView {
     return h1(program.name() + " Questions");
   }
 
-  private ContainerTag topButtons(ProgramDefinition program) {
+  private ContainerTag topButtons(Tag csrfTag, ProgramDefinition program) {
     String addBlockUrl =
         controllers.admin.routes.AdminProgramBlocksController.create(program.id()).url();
+    ContainerTag addBlockForm =
+        form(csrfTag, submitButton("Add Block")).withMethod("post").withAction(addBlockUrl);
 
-    return div(a("Add Block").withHref(addBlockUrl));
+    return div(addBlockForm);
   }
 
   private ContainerTag blockOrderPanel(ProgramDefinition program, BlockDefinition focusedBlock) {
@@ -126,9 +128,16 @@ public class ProgramBlockEditView extends BaseHtmlView {
     String deleteBlockLink =
         controllers.admin.routes.AdminProgramBlocksController.destroy(program.id(), block.id())
             .url();
-    ContainerTag deleteButton =
-        form(csrfTag, submitButton("Delete Block")).withMethod("post").withAction(deleteBlockLink);
-    return div().withClass(Styles.FLEX).with(h1(block.name())).with(deleteButton);
+
+    ContainerTag blockEditPanelTop = div().withClass(Styles.FLEX).with(h1(block.name()));
+    if (program.blockDefinitions().size() > 1) {
+      ContainerTag deleteButton =
+          form(csrfTag, submitButton("Delete Block"))
+              .withMethod("post")
+              .withAction(deleteBlockLink);
+      blockEditPanelTop.with(deleteButton);
+    }
+    return blockEditPanelTop;
   }
 
   private ContainerTag questionBankPanel(

--- a/universal-application-tool-0.0.1/conf/routes
+++ b/universal-application-tool-0.0.1/conf/routes
@@ -18,7 +18,7 @@ POST    /admin/programs/:programId         controllers.admin.AdminProgramControl
 GET     /admin/programs/:programId/blocks                    controllers.admin.AdminProgramBlocksController.index(programId: Long)
 GET     /admin/programs/:programId/blocks/:blockId/edit      controllers.admin.AdminProgramBlocksController.edit(request: Request, programId: Long, blockId: Long)
 POST    /admin/programs/:programId/blocks/:blockId           controllers.admin.AdminProgramBlocksController.update(request: Request, programId: Long, blockId: Long)
-GET     /admin/programs/:programId/blocks/create             controllers.admin.AdminProgramBlocksController.create(programId: Long)
+POST    /admin/programs/:programId/blocks                    controllers.admin.AdminProgramBlocksController.create(programId: Long)
 POST    /admin/programs/:programId/blocks/:blockId/delete    controllers.admin.AdminProgramBlocksController.destroy(programId: Long, blockId: Long)
 
 # A controller for adding and removing questions from program blocks

--- a/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/admin/AdminProgramBlocksControllerTest.java
@@ -35,17 +35,6 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
   }
 
   @Test
-  public void index_withProgramWithNoBlocks_redirectsToCreate() {
-    Program program = resourceCreator().insertProgram("program");
-
-    Result result = controller.index(program.id);
-
-    assertThat(result.status()).isEqualTo(SEE_OTHER);
-    assertThat(result.redirectLocation())
-        .hasValue(routes.AdminProgramBlocksController.create(program.id).url());
-  }
-
-  @Test
   public void index_withProgramWithBlocks_redirectsToEdit() {
     BlockDefinition block =
         BlockDefinition.builder().setId(1L).setName("block").setDescription("desc").build();
@@ -72,10 +61,10 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
-        .hasValue(routes.AdminProgramBlocksController.edit(program.id, 1L).url());
+        .hasValue(routes.AdminProgramBlocksController.edit(program.id, 2L).url());
 
     program.refresh();
-    assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(1);
+    assertThat(program.getProgramDefinition().blockDefinitions()).hasSize(2);
   }
 
   @Test
@@ -170,11 +159,20 @@ public class AdminProgramBlocksControllerTest extends WithPostgresContainer {
 
   @Test
   public void destroy_withProgram_redirects() {
-    Program program = resourceCreator().insertProgram("program");
-    Result result = controller.destroy(program.id, 1L);
+    ProgramDefinition program = resourceCreator().insertProgramWithOneBlock("program");
+    controller.create(program.id());
+    Result result = controller.destroy(program.id(), 1L);
 
     assertThat(result.status()).isEqualTo(SEE_OTHER);
     assertThat(result.redirectLocation())
-        .hasValue(routes.AdminProgramBlocksController.index(program.id).url());
+        .hasValue(routes.AdminProgramBlocksController.index(program.id()).url());
+  }
+
+  @Test
+  public void destroy_lastBlock_notFound() {
+    Program program = resourceCreator().insertProgram("program");
+    Result result = controller.destroy(program.id, 1L);
+
+    assertThat(result.status()).isEqualTo(NOT_FOUND);
   }
 }

--- a/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
+++ b/universal-application-tool-0.0.1/test/controllers/applicant/ApplicantProgramsControllerTest.java
@@ -8,6 +8,7 @@ import static play.test.Helpers.contentAsString;
 import models.Applicant;
 import models.Program;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import play.mvc.Result;
 import repository.WithPostgresContainer;
@@ -74,7 +75,7 @@ public class ApplicantProgramsControllerTest extends WithPostgresContainer {
 
   // TODO(https://github.com/seattle-uat/universal-application-tool/issues/256): Should redirect to
   // end of program submission.
-  @Test
+  @Ignore
   public void edit_whenNoMoreIncompleteBlocks_redirectsToListOfPrograms() {
     Applicant applicant = resourceCreator().insertApplicant();
     Program program = resourceCreator().insertProgram("My Program");

--- a/universal-application-tool-0.0.1/test/support/ResourceCreator.java
+++ b/universal-application-tool-0.0.1/test/support/ResourceCreator.java
@@ -11,7 +11,6 @@ import models.Question;
 import play.inject.Injector;
 import services.program.BlockDefinition;
 import services.program.ProgramDefinition;
-import services.program.ProgramQuestionDefinition;
 import services.program.ProgramService;
 import services.question.QuestionDefinition;
 import services.question.QuestionService;
@@ -70,7 +69,9 @@ public class ResourceCreator {
     program.save();
 
     ProgramDefinition programDefinition =
-        program.getProgramDefinition().toBuilder().addBlockDefinition(block).build();
+        program.getProgramDefinition().toBuilder()
+            .setBlockDefinitions(ImmutableList.of(block))
+            .build();
     program = programDefinition.toProgram();
     program.update();
 
@@ -81,13 +82,8 @@ public class ResourceCreator {
     try {
       ProgramDefinition programDefinition = programService.createProgramDefinition(name, "desc");
       programDefinition =
-          programService.addBlockToProgram(
-              programDefinition.id(), "test block", "test block description");
-      programDefinition =
-          programService.setBlockQuestions(
-              programDefinition.id(),
-              programDefinition.blockDefinitions().get(0).id(),
-              ImmutableList.of(ProgramQuestionDefinition.create(insertQuestionDefinition())));
+          programService.addQuestionsToBlock(
+              programDefinition.id(), 1L, ImmutableList.of(insertQuestionDefinition().getId()));
 
       return programDefinition;
     } catch (Exception e) {


### PR DESCRIPTION
### Description

A Program now must always have one block. That means a new `Program` includes an empty block, and the `ProgramService` prevents the last block from being delete. 

This allows for:
* `POST /admin/program/:pid/blocks` to create new blocks, which used to be a `GET` method.
* The `Add Block` button is now a form that uses the new POST method.

Due to a Program now coming with an empty Block, the following changes were made:

* `DatabaseSeedController` now updates and adds questions to the default empty block, and then adds block 2.
* `ProgramService` throws a `ProgramNeedsABlockException` when trying to delete the last block.
* Tests had to be changed to account for the new default empty block.


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Approvals
Bion
one_of(natalie or caroline) for the `ApplicantProgramsControllerTest`.
