### PR TITLE
Implement question- and field-level validation error interfaces.

### DIFF
--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -6,15 +6,12 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import services.question.AddressQuestionDefinition;
 import services.question.NameQuestionDefinition;
 import services.question.QuestionDefinition;
 import services.question.QuestionType;
 import services.question.TextQuestionDefinition;
 import services.question.TranslationNotFoundException;
-
-import javax.validation.Valid;
 
 /**
  * Represents a question in the context of a specific applicant. Contains non-static inner classes
@@ -80,10 +77,12 @@ public class ApplicantQuestion {
   }
 
   private interface PresentsErrors {
+
     boolean hasErrors();
   }
 
   public class AddressQuestion implements PresentsErrors {
+
     private Optional<String> streetValue;
     private Optional<String> cityValue;
     private Optional<String> stateValue;
@@ -100,12 +99,12 @@ public class ApplicantQuestion {
 
     private ImmutableSet<ValidationErrorMessage> getAllErrors() {
       return ImmutableSet.<ValidationErrorMessage>builder()
-              .addAll(getAddressErrors())
-              .addAll(getStreetErrors())
-              .addAll(getCityErrors())
-              .addAll(getStateErrors())
-              .addAll(getZipErrors())
-              .build();
+          .addAll(getAddressErrors())
+          .addAll(getStreetErrors())
+          .addAll(getCityErrors())
+          .addAll(getStateErrors())
+          .addAll(getZipErrors())
+          .build();
     }
 
     public ImmutableSet<ValidationErrorMessage> getAddressErrors() {
@@ -239,6 +238,7 @@ public class ApplicantQuestion {
   }
 
   public class TextQuestion implements PresentsErrors {
+
     private Optional<String> textValue;
 
     public TextQuestion() {
@@ -285,6 +285,7 @@ public class ApplicantQuestion {
   }
 
   public class NameQuestion implements PresentsErrors {
+
     private Optional<String> firstNameValue;
     private Optional<String> middleNameValue;
     private Optional<String> lastNameValue;
@@ -298,24 +299,24 @@ public class ApplicantQuestion {
       return !getAllErrors().isEmpty();
     }
 
-    public ImmutableSet<String> getAllErrors() {
-      return ImmutableSet.<String>builder()
+    public ImmutableSet<ValidationErrorMessage> getAllErrors() {
+      return ImmutableSet.<ValidationErrorMessage>builder()
           .addAll(getFirstNameErrors())
           .addAll(getLastNameErrors())
           .build();
     }
 
-    public ImmutableSet<String> getFirstNameErrors() {
+    public ImmutableSet<ValidationErrorMessage> getFirstNameErrors() {
       if (hasFirstNameValue() && getFirstNameValue().get().isEmpty()) {
-        return ImmutableSet.of("First name is required.");
+        return ImmutableSet.of(ValidationErrorMessage.create("First name is required."));
       }
 
       return ImmutableSet.of();
     }
 
-    public ImmutableSet<String> getLastNameErrors() {
+    public ImmutableSet<ValidationErrorMessage> getLastNameErrors() {
       if (hasLastNameValue() && getLastNameValue().get().isEmpty()) {
-        return ImmutableSet.of("Last name is required.");
+        return ImmutableSet.of(ValidationErrorMessage.create("Last name is required."));
       }
 
       return ImmutableSet.of();

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -44,7 +44,16 @@ public class ApplicantQuestion {
     }
   }
 
+  public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
+    // TODO: Validate applicantData against validation logic in questionDefinition, if any.
+    return ImmutableSet.of();
+  }
+
   public boolean hasErrors() {
+    if (!getQuestionErrors().isEmpty()) {
+      return true;
+    }
+
     switch (getType()) {
       case ADDRESS:
         return getAddressQuestion().hasErrors();

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -45,7 +45,8 @@ public class ApplicantQuestion {
   }
 
   public ImmutableSet<ValidationErrorMessage> getQuestionErrors() {
-    // TODO: Validate applicantData against validation logic in questionDefinition, if any.
+    // TODO: Once QuestionDefinition has validation predicates, validate applicantData against
+    //  validation logic in questionDefinition, if any.
     return ImmutableSet.of();
   }
 

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantQuestion.java
@@ -2,13 +2,19 @@ package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import services.question.AddressQuestionDefinition;
 import services.question.NameQuestionDefinition;
 import services.question.QuestionDefinition;
 import services.question.QuestionType;
 import services.question.TextQuestionDefinition;
 import services.question.TranslationNotFoundException;
+
+import javax.validation.Valid;
 
 /**
  * Represents a question in the context of a specific applicant. Contains non-static inner classes
@@ -38,6 +44,19 @@ public class ApplicantQuestion {
     }
   }
 
+  public boolean hasErrors() {
+    switch (getType()) {
+      case ADDRESS:
+        return getAddressQuestion().hasErrors();
+      case NAME:
+        return getNameQuestion().hasErrors();
+      case TEXT:
+        return getTextQuestion().hasErrors();
+      default:
+        throw new RuntimeException("Unrecognized question type: " + getType());
+    }
+  }
+
   public AddressQuestion getAddressQuestion() {
     return new AddressQuestion();
   }
@@ -50,7 +69,11 @@ public class ApplicantQuestion {
     return new NameQuestion();
   }
 
-  public class AddressQuestion {
+  private interface PresentsErrors {
+    boolean hasErrors();
+  }
+
+  public class AddressQuestion implements PresentsErrors {
     private Optional<String> streetValue;
     private Optional<String> cityValue;
     private Optional<String> stateValue;
@@ -58,6 +81,68 @@ public class ApplicantQuestion {
 
     public AddressQuestion() {
       assertQuestionType();
+    }
+
+    @Override
+    public boolean hasErrors() {
+      return !getAllErrors().isEmpty();
+    }
+
+    private ImmutableSet<ValidationErrorMessage> getAllErrors() {
+      return ImmutableSet.<ValidationErrorMessage>builder()
+              .addAll(getAddressErrors())
+              .addAll(getStreetErrors())
+              .addAll(getCityErrors())
+              .addAll(getStateErrors())
+              .addAll(getZipErrors())
+              .build();
+    }
+
+    public ImmutableSet<ValidationErrorMessage> getAddressErrors() {
+      // TODO: Implement address validation.
+      return ImmutableSet.of();
+    }
+
+    public ImmutableSet<ValidationErrorMessage> getStreetErrors() {
+      if (hasStreetValue() && getStreetValue().get().isEmpty()) {
+        return ImmutableSet.of(ValidationErrorMessage.create("Street is required."));
+      }
+
+      return ImmutableSet.of();
+    }
+
+    public ImmutableSet<ValidationErrorMessage> getCityErrors() {
+      if (hasCityValue() && getCityValue().get().isEmpty()) {
+        return ImmutableSet.of(ValidationErrorMessage.create("City is required."));
+      }
+
+      return ImmutableSet.of();
+    }
+
+    public ImmutableSet<ValidationErrorMessage> getStateErrors() {
+      // TODO: Validate state further.
+      if (hasStateValue() && getStateValue().get().isEmpty()) {
+        return ImmutableSet.of(ValidationErrorMessage.create("State is required."));
+      }
+
+      return ImmutableSet.of();
+    }
+
+    public ImmutableSet<ValidationErrorMessage> getZipErrors() {
+      if (hasZipValue()) {
+        String zipValue = getZipValue().get();
+        if (zipValue.isEmpty()) {
+          return ImmutableSet.of(ValidationErrorMessage.create("Zip code is required."));
+        }
+
+        Pattern pattern = Pattern.compile("^[0-9]{5}(?:-[0-9]{4})?$");
+        Matcher matcher = pattern.matcher(zipValue);
+        if (!matcher.matches()) {
+          return ImmutableSet.of(ValidationErrorMessage.create("Invalid zip code."));
+        }
+      }
+
+      return ImmutableSet.of();
     }
 
     public boolean hasStreetValue() {
@@ -143,11 +228,17 @@ public class ApplicantQuestion {
     }
   }
 
-  public class TextQuestion {
+  public class TextQuestion implements PresentsErrors {
     private Optional<String> textValue;
 
     public TextQuestion() {
       assertQuestionType();
+    }
+
+    @Override
+    public boolean hasErrors() {
+      // There are no inherent requirements in a text question.
+      return false;
     }
 
     public boolean hasValue() {
@@ -183,13 +274,41 @@ public class ApplicantQuestion {
     }
   }
 
-  public class NameQuestion {
+  public class NameQuestion implements PresentsErrors {
     private Optional<String> firstNameValue;
     private Optional<String> middleNameValue;
     private Optional<String> lastNameValue;
 
     public NameQuestion() {
       assertQuestionType();
+    }
+
+    @Override
+    public boolean hasErrors() {
+      return !getAllErrors().isEmpty();
+    }
+
+    public ImmutableSet<String> getAllErrors() {
+      return ImmutableSet.<String>builder()
+          .addAll(getFirstNameErrors())
+          .addAll(getLastNameErrors())
+          .build();
+    }
+
+    public ImmutableSet<String> getFirstNameErrors() {
+      if (hasFirstNameValue() && getFirstNameValue().get().isEmpty()) {
+        return ImmutableSet.of("First name is required.");
+      }
+
+      return ImmutableSet.of();
+    }
+
+    public ImmutableSet<String> getLastNameErrors() {
+      if (hasLastNameValue() && getLastNameValue().get().isEmpty()) {
+        return ImmutableSet.of("Last name is required.");
+      }
+
+      return ImmutableSet.of();
     }
 
     public boolean hasFirstNameValue() {

--- a/universal-application-tool-0.0.1/app/services/applicant/ValidationErrorMessage.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ValidationErrorMessage.java
@@ -8,7 +8,7 @@ public abstract class ValidationErrorMessage {
   public abstract String message();
 
   // TODO: Ability to get message for a given locale. Probably requires taking in a map from locale
-  // to message.
+  //  to message.
   public static ValidationErrorMessage create(String message) {
     return new AutoValue_ValidationErrorMessage(message);
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ValidationErrorMessage.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ValidationErrorMessage.java
@@ -1,0 +1,15 @@
+package services.applicant;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class ValidationErrorMessage {
+
+  public abstract String message();
+
+  // TODO: Ability to get message for a given locale. Probably requires taking in a map from locale
+  // to message.
+  public static ValidationErrorMessage create(String message) {
+    return new AutoValue_ValidationErrorMessage(message);
+  }
+}

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -1,15 +1,19 @@
 package views;
 
 import static j2html.TagCreator.br;
+import static j2html.TagCreator.div;
+import static j2html.TagCreator.each;
 import static j2html.TagCreator.h1;
 import static j2html.TagCreator.input;
 import static j2html.TagCreator.label;
 import static j2html.TagCreator.option;
 import static j2html.TagCreator.select;
+import static j2html.TagCreator.span;
 import static j2html.TagCreator.text;
 import static j2html.TagCreator.textarea;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import j2html.TagCreator;
 import j2html.attributes.Attr;
 import j2html.tags.ContainerTag;
@@ -18,6 +22,7 @@ import j2html.tags.Tag;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Optional;
 import play.mvc.Http;
+import services.applicant.ValidationErrorMessage;
 import views.html.helper.CSRF;
 
 /**
@@ -30,6 +35,10 @@ public abstract class BaseHtmlView {
 
   public Tag renderHeader(String headerText) {
     return h1(headerText);
+  }
+
+  protected ContainerTag renderFieldErrors(ImmutableSet<ValidationErrorMessage> errors) {
+    return div(each(errors, error -> span(error.message())));
   }
 
   protected ImmutableList<DomContent> textInputWithLabel(

--- a/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
+++ b/universal-application-tool-0.0.1/app/views/BaseHtmlView.java
@@ -37,7 +37,7 @@ public abstract class BaseHtmlView {
     return h1(headerText);
   }
 
-  protected ContainerTag renderFieldErrors(ImmutableSet<ValidationErrorMessage> errors) {
+  protected ContainerTag fieldErrors(ImmutableSet<ValidationErrorMessage> errors) {
     return div(each(errors, error -> span(error.message())));
   }
 

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -30,27 +30,31 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
                 .withCondValue(
                     addressQuestion.hasStreetValue(), addressQuestion.getStreetValue().orElse(""))
                 .withName(addressQuestion.getStreetPath())
-                .withPlaceholder("Street address")),
+                .withPlaceholder("Street address"),
+            renderFieldErrors(addressQuestion.getStreetErrors())),
         label(
             input()
                 .withType("text")
                 .withCondValue(
                     addressQuestion.hasCityValue(), addressQuestion.getCityValue().orElse(""))
                 .withName(addressQuestion.getCityPath())
-                .withPlaceholder("City")),
+                .withPlaceholder("City"),
+            renderFieldErrors(addressQuestion.getCityErrors())),
         label(
             input()
                 .withType("text")
                 .withCondValue(
                     addressQuestion.hasStateValue(), addressQuestion.getStateValue().orElse(""))
                 .withName(addressQuestion.getStatePath())
-                .withPlaceholder("State")),
+                .withPlaceholder("State"),
+            renderFieldErrors(addressQuestion.getStateErrors())),
         label(
             input()
                 .withType("text")
                 .withCondValue(
                     addressQuestion.hasZipValue(), addressQuestion.getZipValue().orElse(""))
                 .withName(addressQuestion.getZipPath())
-                .withPlaceholder("Zip code")));
+                .withPlaceholder("Zip code"),
+            renderFieldErrors(addressQuestion.getZipErrors())));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/AddressQuestionRenderer.java
@@ -31,7 +31,7 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
                     addressQuestion.hasStreetValue(), addressQuestion.getStreetValue().orElse(""))
                 .withName(addressQuestion.getStreetPath().path())
                 .withPlaceholder("Street address"),
-            renderFieldErrors(addressQuestion.getStreetErrors())),
+            fieldErrors(addressQuestion.getStreetErrors())),
         label(
             input()
                 .withType("text")
@@ -39,7 +39,7 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
                     addressQuestion.hasCityValue(), addressQuestion.getCityValue().orElse(""))
                 .withName(addressQuestion.getCityPath().path())
                 .withPlaceholder("City"),
-            renderFieldErrors(addressQuestion.getCityErrors())),
+            fieldErrors(addressQuestion.getCityErrors())),
         label(
             input()
                 .withType("text")
@@ -47,7 +47,7 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
                     addressQuestion.hasStateValue(), addressQuestion.getStateValue().orElse(""))
                 .withName(addressQuestion.getStatePath().path())
                 .withPlaceholder("State"),
-            renderFieldErrors(addressQuestion.getStateErrors())),
+            fieldErrors(addressQuestion.getStateErrors())),
         label(
             input()
                 .withType("text")
@@ -55,6 +55,6 @@ public class AddressQuestionRenderer extends BaseHtmlView implements ApplicantQu
                     addressQuestion.hasZipValue(), addressQuestion.getZipValue().orElse(""))
                 .withName(addressQuestion.getZipPath().path())
                 .withPlaceholder("Zip code"),
-            renderFieldErrors(addressQuestion.getZipErrors())));
+            fieldErrors(addressQuestion.getZipErrors())));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -30,7 +30,7 @@ public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuest
                 .withCondValue(
                     nameQuestion.hasFirstNameValue(), nameQuestion.getFirstNameValue().orElse(""))
                 .withName(nameQuestion.getFirstNamePath().path()),
-            renderFieldErrors(nameQuestion.getFirstNameErrors())),
+            fieldErrors(nameQuestion.getFirstNameErrors())),
         label(
             input()
                 .withType("text")
@@ -43,6 +43,6 @@ public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuest
                 .withCondValue(
                     nameQuestion.hasLastNameValue(), nameQuestion.getLastNameValue().orElse(""))
                 .withName(nameQuestion.getLastNamePath().path()),
-            renderFieldErrors(nameQuestion.getLastNameErrors())));
+            fieldErrors(nameQuestion.getLastNameErrors())));
   }
 }

--- a/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
+++ b/universal-application-tool-0.0.1/app/views/questiontypes/NameQuestionRenderer.java
@@ -29,7 +29,8 @@ public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuest
                 .withType("text")
                 .withCondValue(
                     nameQuestion.hasFirstNameValue(), nameQuestion.getFirstNameValue().orElse(""))
-                .withName(nameQuestion.getFirstNamePath())),
+                .withName(nameQuestion.getFirstNamePath()),
+            renderFieldErrors(nameQuestion.getFirstNameErrors())),
         label(
             input()
                 .withType("text")
@@ -41,6 +42,7 @@ public class NameQuestionRenderer extends BaseHtmlView implements ApplicantQuest
                 .withType("text")
                 .withCondValue(
                     nameQuestion.hasLastNameValue(), nameQuestion.getLastNameValue().orElse(""))
-                .withName(nameQuestion.getLastNamePath())));
+                .withName(nameQuestion.getLastNamePath()),
+            renderFieldErrors(nameQuestion.getLastNameErrors())));
   }
 }

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -1,0 +1,168 @@
+package services.applicant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
+import models.Applicant;
+import org.junit.Before;
+import org.junit.Test;
+import services.question.AddressQuestionDefinition;
+import services.question.NameQuestionDefinition;
+import services.question.TextQuestionDefinition;
+
+public class ApplicantQuestionTest {
+
+  private static final TextQuestionDefinition textQuestionDefinition =
+      new TextQuestionDefinition(
+          1L,
+          "question name",
+          "applicant.my.path.name",
+          "description",
+          ImmutableMap.of(Locale.ENGLISH, "question?"),
+          ImmutableMap.of(Locale.ENGLISH, "help text"));
+  private static final NameQuestionDefinition nameQuestionDefinition =
+      new NameQuestionDefinition(
+          1L,
+          "question name",
+          "applicant.my.path.name",
+          "description",
+          ImmutableMap.of(Locale.ENGLISH, "question?"),
+          ImmutableMap.of(Locale.ENGLISH, "help text"));
+  private static final AddressQuestionDefinition addressQuestionDefinition =
+      new AddressQuestionDefinition(
+          1L,
+          "question name",
+          "applicant.my.path.name",
+          "description",
+          ImmutableMap.of(Locale.ENGLISH, "question?"),
+          ImmutableMap.of(Locale.ENGLISH, "help text"));
+
+  private Applicant applicant;
+  private ApplicantData applicantData;
+
+  @Before
+  public void setUp() {
+    applicant = new Applicant();
+    applicantData = applicant.getApplicantData();
+  }
+
+  @Test
+  public void textQuestion_withEmptyApplicantData() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(textQuestionDefinition, applicantData);
+
+    assertThat(applicantQuestion.getTextQuestion())
+        .isInstanceOf(ApplicantQuestion.TextQuestion.class);
+    assertThat(applicantQuestion.getQuestionText()).isEqualTo("question?");
+    assertThat(applicantQuestion.hasErrors()).isFalse();
+  }
+
+  @Test
+  public void textQuestion_withPresentApplicantData() {
+    applicantData.putString(Path.create(textQuestionDefinition.getPath()), "hello");
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(textQuestionDefinition, applicantData);
+    ApplicantQuestion.TextQuestion textQuestion = applicantQuestion.getTextQuestion();
+
+    assertThat(textQuestion.hasErrors()).isFalse();
+    assertThat(textQuestion.getTextValue().get()).isEqualTo("hello");
+  }
+
+  @Test
+  public void nameQuestion_withEmptyApplicantData() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(nameQuestionDefinition, applicantData);
+
+    assertThat(applicantQuestion.getNameQuestion())
+        .isInstanceOf(ApplicantQuestion.NameQuestion.class);
+    assertThat(applicantQuestion.getQuestionText()).isEqualTo("question?");
+    assertThat(applicantQuestion.hasErrors()).isFalse();
+  }
+
+  @Test
+  public void nameQuestion_withInvalidApplicantData() {
+    applicantData.putString(Path.create(nameQuestionDefinition.getFirstNamePath()), "");
+    applicantData.putString(Path.create(nameQuestionDefinition.getLastNamePath()), "");
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(nameQuestionDefinition, applicantData);
+    ApplicantQuestion.NameQuestion nameQuestion = applicantQuestion.getNameQuestion();
+
+    assertThat(applicantQuestion.hasErrors()).isTrue();
+    assertThat(nameQuestion.getFirstNameErrors())
+        .contains(ValidationErrorMessage.create("First name is required."));
+    assertThat(nameQuestion.getLastNameErrors())
+        .contains(ValidationErrorMessage.create("Last name is required."));
+  }
+
+  @Test
+  public void nameQuestion_withValidApplicantData() {
+    applicantData.putString(Path.create(nameQuestionDefinition.getFirstNamePath()), "Wendel");
+    applicantData.putString(Path.create(nameQuestionDefinition.getLastNamePath()), "Patrick");
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(nameQuestionDefinition, applicantData);
+    ApplicantQuestion.NameQuestion nameQuestion = applicantQuestion.getNameQuestion();
+
+    assertThat(applicantQuestion.hasErrors()).isFalse();
+    assertThat(nameQuestion.getFirstNameValue().get()).isEqualTo("Wendel");
+    assertThat(nameQuestion.getLastNameValue().get()).isEqualTo("Patrick");
+  }
+
+  @Test
+  public void addressQuestion_withEmptyApplicantData() {
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData);
+
+    assertThat(applicantQuestion.getAddressQuestion())
+        .isInstanceOf(ApplicantQuestion.AddressQuestion.class);
+    assertThat(applicantQuestion.getQuestionText()).isEqualTo("question?");
+    assertThat(applicantQuestion.hasErrors()).isFalse();
+  }
+
+  @Test
+  public void addressQuestion_withInvalidApplicantData() {
+    applicantData.putString(Path.create(addressQuestionDefinition.getStreetPath()), "");
+    applicantData.putString(Path.create(addressQuestionDefinition.getCityPath()), "");
+    applicantData.putString(Path.create(addressQuestionDefinition.getStatePath()), "");
+    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "");
+
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData);
+    ApplicantQuestion.AddressQuestion addressQuestion = applicantQuestion.getAddressQuestion();
+
+    assertThat(applicantQuestion.hasErrors()).isTrue();
+    assertThat(addressQuestion.getStreetErrors())
+        .contains(ValidationErrorMessage.create("Street is required."));
+    assertThat(addressQuestion.getCityErrors())
+        .contains(ValidationErrorMessage.create("City is required."));
+    assertThat(addressQuestion.getStateErrors())
+        .contains(ValidationErrorMessage.create("State is required."));
+    assertThat(addressQuestion.getZipErrors())
+        .contains(ValidationErrorMessage.create("Zip code is required."));
+
+    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "not a zip code");
+    addressQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData).getAddressQuestion();
+
+    assertThat(addressQuestion.getZipErrors())
+        .contains(ValidationErrorMessage.create("Invalid zip code."));
+  }
+
+  @Test
+  public void addressQuestion_withValidApplicantData() {
+    applicantData.putString(Path.create(addressQuestionDefinition.getStreetPath()), "85 Pike St");
+    applicantData.putString(Path.create(addressQuestionDefinition.getCityPath()), "Seattle");
+    applicantData.putString(Path.create(addressQuestionDefinition.getStatePath()), "WA");
+    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "98101");
+
+    ApplicantQuestion applicantQuestion =
+        new ApplicantQuestion(addressQuestionDefinition, applicantData);
+    ApplicantQuestion.AddressQuestion addressQuestion = applicantQuestion.getAddressQuestion();
+
+    assertThat(applicantQuestion.hasErrors()).isFalse();
+    assertThat(addressQuestion.getStreetValue().get()).isEqualTo("85 Pike St");
+    assertThat(addressQuestion.getCityValue().get()).isEqualTo("Seattle");
+    assertThat(addressQuestion.getStateValue().get()).isEqualTo("WA");
+    assertThat(addressQuestion.getZipValue().get()).isEqualTo("98101");
+  }
+}

--- a/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
+++ b/universal-application-tool-0.0.1/test/services/applicant/ApplicantQuestionTest.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import models.Applicant;
 import org.junit.Before;
 import org.junit.Test;
+import services.Path;
 import services.question.AddressQuestionDefinition;
 import services.question.NameQuestionDefinition;
 import services.question.TextQuestionDefinition;
@@ -17,7 +18,7 @@ public class ApplicantQuestionTest {
       new TextQuestionDefinition(
           1L,
           "question name",
-          "applicant.my.path.name",
+          Path.create("applicant.my.path.name"),
           "description",
           ImmutableMap.of(Locale.ENGLISH, "question?"),
           ImmutableMap.of(Locale.ENGLISH, "help text"));
@@ -25,7 +26,7 @@ public class ApplicantQuestionTest {
       new NameQuestionDefinition(
           1L,
           "question name",
-          "applicant.my.path.name",
+          Path.create("applicant.my.path.name"),
           "description",
           ImmutableMap.of(Locale.ENGLISH, "question?"),
           ImmutableMap.of(Locale.ENGLISH, "help text"));
@@ -33,7 +34,7 @@ public class ApplicantQuestionTest {
       new AddressQuestionDefinition(
           1L,
           "question name",
-          "applicant.my.path.name",
+          Path.create("applicant.my.path.name"),
           "description",
           ImmutableMap.of(Locale.ENGLISH, "question?"),
           ImmutableMap.of(Locale.ENGLISH, "help text"));
@@ -60,7 +61,7 @@ public class ApplicantQuestionTest {
 
   @Test
   public void textQuestion_withPresentApplicantData() {
-    applicantData.putString(Path.create(textQuestionDefinition.getPath()), "hello");
+    applicantData.putString(textQuestionDefinition.getPath(), "hello");
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(textQuestionDefinition, applicantData);
     ApplicantQuestion.TextQuestion textQuestion = applicantQuestion.getTextQuestion();
@@ -82,8 +83,8 @@ public class ApplicantQuestionTest {
 
   @Test
   public void nameQuestion_withInvalidApplicantData() {
-    applicantData.putString(Path.create(nameQuestionDefinition.getFirstNamePath()), "");
-    applicantData.putString(Path.create(nameQuestionDefinition.getLastNamePath()), "");
+    applicantData.putString(nameQuestionDefinition.getFirstNamePath(), "");
+    applicantData.putString(nameQuestionDefinition.getLastNamePath(), "");
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(nameQuestionDefinition, applicantData);
     ApplicantQuestion.NameQuestion nameQuestion = applicantQuestion.getNameQuestion();
@@ -97,8 +98,8 @@ public class ApplicantQuestionTest {
 
   @Test
   public void nameQuestion_withValidApplicantData() {
-    applicantData.putString(Path.create(nameQuestionDefinition.getFirstNamePath()), "Wendel");
-    applicantData.putString(Path.create(nameQuestionDefinition.getLastNamePath()), "Patrick");
+    applicantData.putString(nameQuestionDefinition.getFirstNamePath(), "Wendel");
+    applicantData.putString(nameQuestionDefinition.getLastNamePath(), "Patrick");
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(nameQuestionDefinition, applicantData);
     ApplicantQuestion.NameQuestion nameQuestion = applicantQuestion.getNameQuestion();
@@ -121,10 +122,10 @@ public class ApplicantQuestionTest {
 
   @Test
   public void addressQuestion_withInvalidApplicantData() {
-    applicantData.putString(Path.create(addressQuestionDefinition.getStreetPath()), "");
-    applicantData.putString(Path.create(addressQuestionDefinition.getCityPath()), "");
-    applicantData.putString(Path.create(addressQuestionDefinition.getStatePath()), "");
-    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "");
+    applicantData.putString(addressQuestionDefinition.getStreetPath(), "");
+    applicantData.putString(addressQuestionDefinition.getCityPath(), "");
+    applicantData.putString(addressQuestionDefinition.getStatePath(), "");
+    applicantData.putString(addressQuestionDefinition.getZipPath(), "");
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(addressQuestionDefinition, applicantData);
@@ -140,7 +141,7 @@ public class ApplicantQuestionTest {
     assertThat(addressQuestion.getZipErrors())
         .contains(ValidationErrorMessage.create("Zip code is required."));
 
-    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "not a zip code");
+    applicantData.putString(addressQuestionDefinition.getZipPath(), "not a zip code");
     addressQuestion =
         new ApplicantQuestion(addressQuestionDefinition, applicantData).getAddressQuestion();
 
@@ -150,10 +151,10 @@ public class ApplicantQuestionTest {
 
   @Test
   public void addressQuestion_withValidApplicantData() {
-    applicantData.putString(Path.create(addressQuestionDefinition.getStreetPath()), "85 Pike St");
-    applicantData.putString(Path.create(addressQuestionDefinition.getCityPath()), "Seattle");
-    applicantData.putString(Path.create(addressQuestionDefinition.getStatePath()), "WA");
-    applicantData.putString(Path.create(addressQuestionDefinition.getZipPath()), "98101");
+    applicantData.putString(addressQuestionDefinition.getStreetPath(), "85 Pike St");
+    applicantData.putString(addressQuestionDefinition.getCityPath(), "Seattle");
+    applicantData.putString(addressQuestionDefinition.getStatePath(), "WA");
+    applicantData.putString(addressQuestionDefinition.getZipPath(), "98101");
 
     ApplicantQuestion applicantQuestion =
         new ApplicantQuestion(addressQuestionDefinition, applicantData);


### PR DESCRIPTION
### Description
* Add methods on question types, ApplicantQuestion, and Block for determining whether there are any validation errors.
* Render field-level (e.g., first name or zip code) error messages on address and name questions.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
Works toward #361 and #100 
