### PR TITLE
Turn off sbt scala doc link warnings

### DIFF
--- a/universal-application-tool-0.0.1/app/services/program/ProgramService.java
+++ b/universal-application-tool-0.0.1/app/services/program/ProgramService.java
@@ -161,8 +161,8 @@ public interface ProgramService {
    * @param programId the ID of the program to update
    * @param blockDefinitionId the ID of the block to update
    * @param predicate the {@link Predicate} for hiding the block
-   * @return the updated {@link ProgramDefinition} * @throws ProgramNotFoundException when programId
-   *     does not correspond to a real Program.
+   * @return the updated {@link ProgramDefinition}
+   * @throws ProgramNotFoundException when programId does not correspond to a real Program.
    */
   ProgramDefinition setBlockHidePredicate(
       long programId, long blockDefinitionId, Predicate predicate)

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -6,6 +6,8 @@ lazy val root = (project in file("."))
     name := """universal-application-tool""",
     version := "0.0.1",
     scalaVersion := "2.13.1",
+    autoAPIMappings := true,
+    maintainer := "uat-public-contact@google.com",
     libraryDependencies ++= Seq(
       guice,
       javaJdbc,

--- a/universal-application-tool-0.0.1/build.sbt
+++ b/universal-application-tool-0.0.1/build.sbt
@@ -6,7 +6,6 @@ lazy val root = (project in file("."))
     name := """universal-application-tool""",
     version := "0.0.1",
     scalaVersion := "2.13.1",
-    autoAPIMappings := true,
     maintainer := "uat-public-contact@google.com",
     libraryDependencies ++= Seq(
       guice,
@@ -79,7 +78,10 @@ lazy val root = (project in file("."))
     ),
     // Make verbose tests
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
-    javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
+    // Use test config for tests
+    javaOptions in Test += "-Dconfig.file=conf/application.test.conf",
+    // Turn off scaladoc link warnings
+    scalacOptions in (Compile, doc) += "-no-link-warnings"
   )
 JsEngineKeys.engineType := JsEngineKeys.EngineType.Node
 resolvers += Resolver.bintrayRepo("webjars","maven")


### PR DESCRIPTION
### Description
sbt compiles doc with scaladoc and does not properly render javadoc links when referring to classes outside the package. Suppress the warning as we cannot do anything about it.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #<issue_number>
