### PR TITLE
Implement `ApplicantService.stageAndUpdateIfValid`.

### DIFF
--- a/universal-application-tool-0.0.1/app/models/Applicant.java
+++ b/universal-application-tool-0.0.1/app/models/Applicant.java
@@ -1,10 +1,10 @@
 package models;
 
 import io.ebean.annotation.DbJson;
-import java.io.IOException;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import play.data.validation.Constraints;
 import services.applicant.ApplicantData;
@@ -38,11 +38,12 @@ public class Applicant extends BaseModel {
   }
 
   @PrePersist
-  public void synchronizeObject() throws IOException {
+  @PreUpdate
+  public void synchronizeObject() {
     this.object = objectAsJsonString();
   }
 
-  private String objectAsJsonString() throws IOException {
+  private String objectAsJsonString() {
     return getApplicantData().asJsonString();
   }
 

--- a/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
+++ b/universal-application-tool-0.0.1/app/repository/ApplicantRepository.java
@@ -41,6 +41,15 @@ public class ApplicantRepository {
         executionContext);
   }
 
+  public CompletionStage<Void> updateApplicant(Applicant applicant) {
+    return supplyAsync(
+        () -> {
+          ebeanServer.update(applicant);
+          return null;
+        },
+        executionContext);
+  }
+
   public Optional<Applicant> lookupApplicantSync(long id) {
     return ebeanServer.find(Applicant.class).setId(id).findOneOrEmpty();
   }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantData.java
@@ -20,9 +20,9 @@ public class ApplicantData {
   // blob.
   private static final Configuration CONFIGURATION =
       Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS);
+  private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
 
   private DocumentContext jsonData;
-  private static final String EMPTY_APPLICANT_DATA_JSON = "{ \"applicant\": {}, \"metadata\": {} }";
 
   public ApplicantData() {
     this(EMPTY_APPLICANT_DATA_JSON);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -18,7 +18,7 @@ public interface ApplicantService {
    *     invalid data with errors associated with it. If the service cannot perform the update, an
    *     {@link ErrorAnd} is returned in the error state.
    */
-  CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, String>> stageAndUpdateIfValid(
+  CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, Exception>> stageAndUpdateIfValid(
       long applicantId, long programId, long blockId, ImmutableSet<Update> updates);
 
   /** Creates a new {@link models.Applicant} at for latest application version for a given user. */

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantService.java
@@ -9,12 +9,17 @@ import services.ErrorAnd;
 public interface ApplicantService {
 
   /**
-   * Performs a set of updates to the applicant's {@link ApplicantData}. Updates are atomic i.e. if
-   * any of them fail validation none of them will be written. programId is used to construct the
-   * {@link ReadOnlyApplicantProgramService} provided in the return value.
+   * Attempts to perform a set of updates to the applicant's {@link ApplicantData}. If updates are
+   * valid, they are saved to storage.
+   *
+   * <p>Updates are atomic i.e. if any of them fail validation none of them will be written.
+   *
+   * @return a {@link ReadOnlyApplicantProgramService} that reflects the updates, which may have
+   *     invalid data with errors associated with it. If the service cannot perform the update, an
+   *     {@link ErrorAnd} is returned in the error state.
    */
-  CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, UpdateError>> update(
-      long applicantId, long programId, ImmutableSet<Update> updates);
+  CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, String>> stageAndUpdateIfValid(
+      long applicantId, long programId, long blockId, ImmutableSet<Update> updates);
 
   /** Creates a new {@link models.Applicant} at for latest application version for a given user. */
   CompletionStage<Applicant> createApplicant(long userId);

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -2,6 +2,7 @@ package services.applicant;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -11,8 +12,12 @@ import models.Applicant;
 import play.libs.concurrent.HttpExecutionContext;
 import repository.ApplicantRepository;
 import services.ErrorAnd;
+import services.program.BlockDefinition;
+import services.program.PathNotInBlockException;
 import services.program.ProgramDefinition;
 import services.program.ProgramService;
+import services.question.ScalarType;
+import services.question.UnsupportedScalarTypeException;
 
 public class ApplicantServiceImpl implements ApplicantService {
 
@@ -31,9 +36,42 @@ public class ApplicantServiceImpl implements ApplicantService {
   }
 
   @Override
-  public CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, UpdateError>> update(
-      long applicantId, long programId, ImmutableSet<Update> updates) {
-    throw new UnsupportedOperationException();
+  public CompletionStage<ErrorAnd<ReadOnlyApplicantProgramService, String>> stageAndUpdateIfValid(
+      long applicantId, long programId, long blockId, ImmutableSet<Update> updates) {
+    CompletableFuture<Optional<Applicant>> applicantCompletableFuture =
+        applicantRepository.lookupApplicant(applicantId).toCompletableFuture();
+
+    CompletableFuture<Optional<ProgramDefinition>> programDefinitionCompletableFuture =
+        programService.getProgramDefinitionAsync(programId).toCompletableFuture();
+
+    return CompletableFuture.allOf(applicantCompletableFuture, programDefinitionCompletableFuture)
+        .thenComposeAsync(
+            (v) -> {
+              Applicant applicant = applicantCompletableFuture.join().get();
+              ProgramDefinition programDefinition = programDefinitionCompletableFuture.join().get();
+
+              ImmutableSet<String> updateErrors =
+                  stageUpdates(applicant, programDefinition, blockId, updates);
+              if (!updateErrors.isEmpty()) {
+                return CompletableFuture.completedFuture(ErrorAnd.error(updateErrors));
+              }
+
+              ReadOnlyApplicantProgramService roApplicantProgramService =
+                  new ReadOnlyApplicantProgramServiceImpl(
+                      applicant.getApplicantData(), programDefinition);
+
+              Optional<Block> blockMaybe = roApplicantProgramService.getBlock(blockId);
+              if (blockMaybe.get().isValid()) {
+                return applicantRepository
+                    .updateApplicant(applicant)
+                    .thenApplyAsync(
+                        (finishedSaving) -> ErrorAnd.of(roApplicantProgramService),
+                        httpExecutionContext.current());
+              }
+
+              return CompletableFuture.completedFuture(ErrorAnd.of(roApplicantProgramService));
+            },
+            httpExecutionContext.current());
   }
 
   @Override
@@ -60,5 +98,60 @@ public class ApplicantServiceImpl implements ApplicantService {
                   applicant.getApplicantData(), programDefinition);
             },
             httpExecutionContext.current());
+  }
+
+  /**
+   * Tries to perform an in-place update of {@link ApplicantData}. Returns error messages if it is
+   * impossible to perform the operation.
+   */
+  private ImmutableSet<String> stageUpdates(
+      Applicant applicant,
+      ProgramDefinition programDefinition,
+      long blockId,
+      ImmutableSet<Update> updates) {
+
+    Optional<BlockDefinition> blockDefinitionMaybe = programDefinition.getBlockDefinition(blockId);
+    if (blockDefinitionMaybe.isEmpty()) {
+      return ImmutableSet.of("Block not found.");
+    }
+    BlockDefinition blockDefinition = blockDefinitionMaybe.get();
+
+    ImmutableList<Path> updatePaths =
+        updates.stream().map(Update::path).collect(ImmutableList.toImmutableList());
+    if (!blockDefinition.hasPaths(updatePaths)) {
+      return ImmutableSet.of("Not all paths exist in this Block.");
+    }
+
+    try {
+      stageUpdates(applicant.getApplicantData(), blockDefinition, updates);
+    } catch (UnsupportedScalarTypeException e) {
+      return ImmutableSet.of("Unrecognized scalar type");
+    } catch (PathNotInBlockException e) {
+      return ImmutableSet.of("Update path does not exist.");
+    }
+
+    return ImmutableSet.of();
+  }
+
+  /** In-place update of applicant data. */
+  private void stageUpdates(
+      ApplicantData applicantData, BlockDefinition blockDefinition, ImmutableSet<Update> updates)
+      throws UnsupportedScalarTypeException, PathNotInBlockException {
+    for (Update update : updates) {
+      Optional<ScalarType> typeMaybe = blockDefinition.getScalarType(update.path());
+      if (typeMaybe.isEmpty()) {
+        throw new PathNotInBlockException(blockDefinition, update.path());
+      }
+      switch (typeMaybe.get()) {
+        case STRING:
+          applicantData.putString(update.path(), (String) update.value());
+          break;
+        case INT:
+          applicantData.putInteger(update.path(), (Integer) update.value());
+          break;
+        default:
+          throw new UnsupportedScalarTypeException(typeMaybe.get());
+      }
+    }
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/ApplicantServiceImpl.java
@@ -64,7 +64,7 @@ public class ApplicantServiceImpl implements ApplicantService {
                       applicant.getApplicantData(), programDefinition);
 
               Optional<Block> blockMaybe = roApplicantProgramService.getBlock(blockId);
-              if (blockMaybe.get().isValid()) {
+              if (!blockMaybe.get().hasErrors()) {
                 return applicantRepository
                     .updateApplicant(applicant)
                     .thenApplyAsync(

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -62,8 +62,4 @@ public final class Block {
     }
     return errorsMemo.get();
   }
-
-  public boolean isValid() {
-    return true;
-  }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/Block.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Block.java
@@ -43,4 +43,8 @@ public final class Block {
         .map(questionDefinition -> new ApplicantQuestion(questionDefinition, applicantData))
         .collect(toImmutableList());
   }
+
+  public boolean isValid() {
+    return true;
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/Update.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Update.java
@@ -12,9 +12,9 @@ public abstract class Update {
   public abstract Path path();
 
   /** The value to update the the applicant's {@link ApplicantData} to. */
-  public abstract Object value();
+  public abstract String value();
 
-  public static Update create(Path path, Object value) {
+  public static Update create(Path path, String value) {
     return new AutoValue_Update(path, value);
   }
 }

--- a/universal-application-tool-0.0.1/app/services/applicant/Update.java
+++ b/universal-application-tool-0.0.1/app/services/applicant/Update.java
@@ -9,8 +9,12 @@ public abstract class Update {
    * A JSON-style path pointing to a scalar value to update in the applicant's {@link
    * ApplicantData}.
    */
-  public abstract String path();
+  public abstract Path path();
 
   /** The value to update the the applicant's {@link ApplicantData} to. */
-  public abstract String value();
+  public abstract Object value();
+
+  public static Update create(Path path, Object value) {
+    return new AutoValue_Update(path, value);
+  }
 }

--- a/universal-application-tool-0.0.1/app/services/program/PathNotInBlockException.java
+++ b/universal-application-tool-0.0.1/app/services/program/PathNotInBlockException.java
@@ -1,0 +1,14 @@
+package services.program;
+
+import services.applicant.Path;
+
+public class PathNotInBlockException extends Exception {
+
+  // TODO: use block definition's reference to its program definition for ProgramDefinition.id when
+  // it is available.
+  public PathNotInBlockException(BlockDefinition block, Path path) {
+    super(
+        String.format(
+            "Block (ID %d) in program (ID ?) does not contain path %s", block.id(), path.path()));
+  }
+}

--- a/universal-application-tool-0.0.1/app/services/question/ScalarType.java
+++ b/universal-application-tool-0.0.1/app/services/question/ScalarType.java
@@ -3,13 +3,7 @@ package services.question;
 import java.util.Optional;
 
 public enum ScalarType {
-  BOOLEAN(boolean.class),
-  BYTE(byte.class),
-  CHAR(char.class),
-  DOUBLE(double.class),
-  FLOAT(float.class),
   INT(int.class),
-  SHORT(short.class),
   STRING(String.class);
 
   ScalarType(Class classOf) {

--- a/universal-application-tool-0.0.1/app/services/question/UnsupportedScalarTypeException.java
+++ b/universal-application-tool-0.0.1/app/services/question/UnsupportedScalarTypeException.java
@@ -1,0 +1,8 @@
+package services.question;
+
+public class UnsupportedScalarTypeException extends Exception {
+
+  public UnsupportedScalarTypeException(ScalarType type) {
+    super(String.format("Scalar type %s is unsupported", type));
+  }
+}

--- a/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
+++ b/universal-application-tool-0.0.1/test/repository/ApplicantRepositoryTest.java
@@ -53,14 +53,27 @@ public class ApplicantRepositoryTest extends WithPostgresContainer {
   }
 
   @Test
-  public void insertApplicant() throws Exception {
+  public void insertApplicant() {
     Applicant applicant = new Applicant();
     String path = "$.applicant.birthdate";
     applicant.getApplicantData().putString(Path.create(path), "1/1/2021");
 
-    assertThat(applicant.getApplicantData().readString(Path.create(path))).hasValue("1/1/2021");
-
     repo.insertApplicant(applicant).toCompletableFuture().join();
+
+    long id = applicant.id;
+    Applicant a = repo.lookupApplicant(id).toCompletableFuture().join().get();
+    assertThat(a.id).isEqualTo(id);
+    assertThat(a.getApplicantData().readString(Path.create(path))).hasValue("1/1/2021");
+  }
+
+  @Test
+  public void updateApplicant() {
+    Applicant applicant = new Applicant();
+    repo.insertApplicant(applicant).toCompletableFuture().join();
+    String path = "$.applicant.birthdate";
+    applicant.getApplicantData().putString(Path.create(path), "1/1/2021");
+
+    repo.updateApplicant(applicant).toCompletableFuture().join();
 
     long id = applicant.id;
     Applicant a = repo.lookupApplicant(id).toCompletableFuture().join().get();

--- a/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
+++ b/universal-application-tool-0.0.1/test/services/program/BlockDefinitionTest.java
@@ -2,7 +2,15 @@ package services.program;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 import org.junit.Test;
+import services.applicant.Path;
+import services.question.QuestionDefinition;
+import services.question.QuestionDefinitionBuilder;
+import services.question.QuestionType;
+import services.question.ScalarType;
 
 public class BlockDefinitionTest {
   @Test
@@ -14,5 +22,91 @@ public class BlockDefinitionTest {
             .setDescription("Block Description")
             .build();
     assertThat(block.id()).isEqualTo(123L);
+  }
+
+  @Test
+  public void getScalarType() throws Exception {
+    BlockDefinition block = makeBlockDefinitionWithQuestions();
+    assertThat(block.getScalarType(Path.create("applicant.name.first")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.name.middle")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.name.last"))).hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.address.street")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.address.city")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.address.state")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.address.zip")))
+        .hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("applicant.color"))).hasValue(ScalarType.STRING);
+    assertThat(block.getScalarType(Path.create("fake.path"))).isEmpty();
+  }
+
+  @Test
+  public void hasPaths() throws Exception {
+    BlockDefinition block = makeBlockDefinitionWithQuestions();
+    ImmutableList<Path> paths =
+        ImmutableList.of(
+            Path.create("applicant.name.first"),
+            Path.create("applicant.name.middle"),
+            Path.create("applicant.name.last"),
+            Path.create("applicant.address.street"),
+            Path.create("applicant.address.city"),
+            Path.create("applicant.address.state"),
+            Path.create("applicant.address.zip"),
+            Path.create("applicant.color"));
+
+    assertThat(block.hasPaths(paths)).isTrue();
+
+    assertThat(block.hasPaths(Path.create("fake.path"))).isFalse();
+  }
+
+  private BlockDefinition makeBlockDefinitionWithQuestions() throws Exception {
+    QuestionDefinition nameQuestion =
+        new QuestionDefinitionBuilder()
+            .setId(1L)
+            .setVersion(1L)
+            .setName("name")
+            .setPath("applicant.name")
+            .setDescription("name question")
+            .setQuestionType(QuestionType.NAME)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "What is your name?"))
+            .setQuestionHelpText(ImmutableMap.of())
+            .build();
+    QuestionDefinition addressQuestion =
+        new QuestionDefinitionBuilder()
+            .setId(2L)
+            .setVersion(1L)
+            .setName("address")
+            .setPath("applicant.address")
+            .setDescription("address question")
+            .setQuestionType(QuestionType.ADDRESS)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "What is your address?"))
+            .setQuestionHelpText(ImmutableMap.of())
+            .build();
+    QuestionDefinition colorQuestion =
+        new QuestionDefinitionBuilder()
+            .setId(3L)
+            .setVersion(1L)
+            .setName("color")
+            .setPath("applicant.color")
+            .setDescription("color")
+            .setQuestionType(QuestionType.TEXT)
+            .setQuestionText(ImmutableMap.of(Locale.ENGLISH, "What is your favorite color?"))
+            .setQuestionHelpText(ImmutableMap.of())
+            .build();
+
+    BlockDefinition block =
+        BlockDefinition.builder()
+            .setId(123L)
+            .setName("Block Name")
+            .setDescription("Block Description")
+            .addQuestion(ProgramQuestionDefinition.create(nameQuestion))
+            .addQuestion(ProgramQuestionDefinition.create(addressQuestion))
+            .addQuestion(ProgramQuestionDefinition.create(colorQuestion))
+            .build();
+    return block;
   }
 }


### PR DESCRIPTION
Rename `ApplicantService.update` to `ApplicantService.stageAndUpdateIfValid`, and then implement it.

Started from https://github.com/seattle-uat/universal-application-tool/pull/331.

### Description
The `stageAndUpdateIfValid` method tries to stage updates for a block. If there are unexpected problems with the program, block, or updates, then errors are returned with `ErrorAnd`. If there updates are staged, then a `ReadOnlyApplicantService` is returned that may contain invalid applicant data. 

Not implemented: the `ApplicantQuestion`s will be responsible for validating the staged applicant data. When available, `Block.isValid` is check if its `ApplicantQuestion`s are in a valid state. For now it just returns `true`.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #100  

### Approvals
ALL_OF(natsid, carolinedanzi)