### PR TITLE
Download secrets / provide secrets to uat container.

### DIFF
--- a/bin/refresh-secrets
+++ b/bin/refresh-secrets
@@ -1,0 +1,2 @@
+#! /bin/bash
+aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-west-2:405662711265:secret:dev-oidc-secrets-RYkDFb | jq -r .SecretString | jq -r '. | to_entries | .[] | "export \(.key)=\(.value)"' > .secrets

--- a/bin/run-dev
+++ b/bin/run-dev
@@ -10,4 +10,8 @@ if [ -z "$USE_LOCAL_UAT" ]; then
 	docker tag public.ecr.aws/t1q6b4h2/uat-dev:latest uat
 fi
 
+if [ -f ".secrets" ]; then
+	. .secrets
+fi
+
 docker-compose up


### PR DESCRIPTION
### Description
Follow-on to #383.  Adds a binary to download the secrets and updates `bin/run-dev` to use them if present.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary (added to wiki)