### PR TITLE
Raise exception if merging profiles that use different email addresses.

### DIFF
--- a/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/AdfsProfileAdapter.java
@@ -1,5 +1,6 @@
 package auth;
 
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -26,9 +27,9 @@ public class AdfsProfileAdapter extends UatProfileAdapter {
   @Override
   public UatProfileData mergeUatProfile(UatProfile uatProfile, OidcProfile oidcProfile) {
     // The key in AD is just "email".
-    // TODO(https://github.com/seattle-uat/universal-application-tool/issues/385): what if there's
-    // already an email?
-    uatProfile.setEmailAddress(oidcProfile.getAttribute("email", String.class)).join();
+    String emailAddress = oidcProfile.getAttribute("email", String.class);
+    uatProfile.setEmailAddress(emailAddress).join();
+    uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     return uatProfile.getProfileData();
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
+++ b/universal-application-tool-0.0.1/app/auth/IdcsProfileAdapter.java
@@ -1,5 +1,6 @@
 package auth;
 
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -30,9 +31,9 @@ public class IdcsProfileAdapter extends UatProfileAdapter {
     // because the two systems hold totally different amounts of data - IDCS holds almost
     // nothing while AD holds a lot - even though at time of writing they're identical except
     // for this line.
-    // TODO(https://github.com/seattle-uat/universal-application-tool/issues/385): what if there's
-    // already an email?
-    uatProfile.setEmailAddress(oidcProfile.getAttribute("user_emailid", String.class)).join();
+    String emailAddress = oidcProfile.getAttribute("user_emailid", String.class);
+    uatProfile.setEmailAddress(emailAddress).join();
+    uatProfile.getProfileData().addAttribute(CommonProfileDefinition.EMAIL, emailAddress);
     return uatProfile.getProfileData();
   }
 }

--- a/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
@@ -7,8 +7,8 @@ public class ProfileMergeConflictException extends HttpAction implements WithCon
   private final String message;
 
   /**
-   * When this exception is thrown in a controlller, the resulting response will be a 400 and
-   * the provided message will be displayed to the user (unformatted, for now).
+   * When this exception is thrown in a controlller, the resulting response will be a 400 and the
+   * provided message will be displayed to the user (unformatted, for now).
    */
   ProfileMergeConflictException(String message) {
     super(400);

--- a/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
@@ -1,0 +1,18 @@
+package auth;
+
+import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.exception.http.WithContentAction;
+
+public class ProfileMergeConflictException extends HttpAction implements WithContentAction {
+  private final String message;
+
+  ProfileMergeConflictException(String message) {
+    super(400);
+    this.message = message;
+  }
+
+  @Override
+  public String getContent() {
+    return String.format("Failed to merge your existing profile with the new one: \"%s\"", message);
+  }
+}

--- a/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
+++ b/universal-application-tool-0.0.1/app/auth/ProfileMergeConflictException.java
@@ -6,6 +6,10 @@ import org.pac4j.core.exception.http.WithContentAction;
 public class ProfileMergeConflictException extends HttpAction implements WithContentAction {
   private final String message;
 
+  /**
+   * When this exception is thrown in a controlller, the resulting response will be a 400 and
+   * the provided message will be displayed to the user (unformatted, for now).
+   */
   ProfileMergeConflictException(String message) {
     super(400);
     this.message = message;

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -76,8 +76,17 @@ public class UatProfile {
     return this.getAccount()
         .thenApplyAsync(
             a -> {
-              a.setEmailAddress(emailAddress);
-              a.save();
+              String existingEmail = a.getEmailAddress();
+              if (existingEmail == null || existingEmail.equals("")) {
+                a.setEmailAddress(emailAddress);
+                a.save();
+              } else if (!existingEmail.equals(emailAddress)) {
+                throw new ProfileMergeConflictException(
+                    String.format(
+                        "Profile already contains an email address: %s - which is different from"
+                            + " the new email address %s.",
+                        existingEmail, emailAddress));
+              }
               return null;
             },
             dbContext);

--- a/universal-application-tool-0.0.1/app/auth/UatProfile.java
+++ b/universal-application-tool-0.0.1/app/auth/UatProfile.java
@@ -77,7 +77,7 @@ public class UatProfile {
         .thenApplyAsync(
             a -> {
               String existingEmail = a.getEmailAddress();
-              if (existingEmail == null || existingEmail.equals("")) {
+              if (existingEmail == null || existingEmail.isEmpty()) {
                 a.setEmailAddress(emailAddress);
                 a.save();
               } else if (!existingEmail.equals(emailAddress)) {

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -20,7 +20,6 @@ public class ProfileMergeTest extends WithPostgresContainer {
     profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
   }
 
-
   @Test
   public void testProfileCreation() throws ExecutionException, InterruptedException {
     OidcProfile oidcProfile = new OidcProfile();

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -4,15 +4,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.ExecutionException;
+import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.oidc.profile.OidcProfile;
 import repository.WithPostgresContainer;
 
 public class ProfileMergeTest extends WithPostgresContainer {
+
+  private IdcsProfileAdapter profileAdapter;
+  private ProfileFactory profileFactory;
+
+  @Before
+  public void setupFactory() {
+    profileFactory = instanceOf(ProfileFactory.class);
+    profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
+  }
+
+
   @Test
   public void testProfileCreation() throws ExecutionException, InterruptedException {
-    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
-    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
@@ -25,8 +35,6 @@ public class ProfileMergeTest extends WithPostgresContainer {
 
   @Test
   public void testSuccessfulProfileMerge() {
-    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
-    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
 
@@ -41,8 +49,6 @@ public class ProfileMergeTest extends WithPostgresContainer {
 
   @Test
   public void testFailedProfileMerge() {
-    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
-    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
     OidcProfile oidcProfile = new OidcProfile();
     oidcProfile.addAttribute("user_emailid", "foo@example.com");
     OidcProfile conflictingProfile = new OidcProfile();

--- a/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
+++ b/universal-application-tool-0.0.1/test/auth/ProfileMergeTest.java
@@ -1,0 +1,59 @@
+package auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+import org.pac4j.oidc.profile.OidcProfile;
+import repository.WithPostgresContainer;
+
+public class ProfileMergeTest extends WithPostgresContainer {
+  @Test
+  public void testProfileCreation() throws ExecutionException, InterruptedException {
+    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
+    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
+    OidcProfile oidcProfile = new OidcProfile();
+    oidcProfile.addAttribute("user_emailid", "foo@example.com");
+
+    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+    UatProfile profile = profileFactory.wrapProfileData(profileData);
+
+    assertThat(profileData.getEmail()).isEqualTo("foo@example.com");
+    assertThat(profile.getEmailAddress().get()).isEqualTo("foo@example.com");
+  }
+
+  @Test
+  public void testSuccessfulProfileMerge() {
+    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
+    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
+    OidcProfile oidcProfile = new OidcProfile();
+    oidcProfile.addAttribute("user_emailid", "foo@example.com");
+
+    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+
+    assertThat(
+            profileAdapter
+                .mergeUatProfile(profileFactory.wrapProfileData(profileData), oidcProfile)
+                .getEmail())
+        .isEqualTo("foo@example.com");
+  }
+
+  @Test
+  public void testFailedProfileMerge() {
+    ProfileFactory profileFactory = app.injector().instanceOf(ProfileFactory.class);
+    IdcsProfileAdapter profileAdapter = new IdcsProfileAdapter(null, null, profileFactory);
+    OidcProfile oidcProfile = new OidcProfile();
+    oidcProfile.addAttribute("user_emailid", "foo@example.com");
+    OidcProfile conflictingProfile = new OidcProfile();
+    oidcProfile.addAttribute("user_emailid", "bar@example.com");
+
+    UatProfileData profileData = profileAdapter.uatProfileFromOidcProfile(oidcProfile);
+
+    assertThatThrownBy(
+            () ->
+                profileAdapter.mergeUatProfile(
+                    profileFactory.wrapProfileData(profileData), conflictingProfile))
+        .hasCauseInstanceOf(ProfileMergeConflictException.class);
+  }
+}


### PR DESCRIPTION
### Description
As follow-up to #383, handle email merges, initially by ensuring that no email merges take place.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary

### Issue(s)
[Fixes] #385 
